### PR TITLE
add channel list

### DIFF
--- a/src/Web/Slack.hs
+++ b/src/Web/Slack.hs
@@ -19,6 +19,7 @@ module Web.Slack
   , authTest
   , chatPostMessage
   , channelsCreate
+  , channelsList
   , authenticateReq
   )
   where
@@ -69,6 +70,11 @@ type Api =
       :> AuthProtect "token"
       :> ReqBody '[FormUrlEncoded] Channel.CreateReq
       :> Post '[JSON] Channel.CreateRsp
+  :<|>
+    "channels.list"
+      :> AuthProtect "token"
+      :> ReqBody '[FormUrlEncoded] Channel.ListReq
+      :> Post '[JSON] Channel.ListRsp
   :<|>
     "chat.postMessage"
       :> AuthProtect "token"
@@ -122,6 +128,23 @@ channelsCreate_
   -> Channel.CreateReq
   -> ClientM Channel.CreateRsp
 
+-- |
+--
+-- Retrieve channel history.
+--
+-- <https://api.slack.com/methods/channels.history>
+
+channelsList
+  :: Text
+  -> Channel.ListReq
+  -> ClientM Channel.ListRsp
+channelsList token =
+  channelsList_ (mkAuthenticateReq token authenticateReq)
+
+channelsList_
+  :: AuthenticateReq (AuthProtect "token")
+  -> Channel.ListReq
+  -> ClientM Channel.ListRsp
 
 -- |
 --
@@ -145,6 +168,7 @@ chatPostMessage_
 apiTest
   :<|> authTest_
   :<|> channelsCreate_
+  :<|> channelsList_
   :<|> chatPostMessage_
   =
   client (Proxy :: Proxy Api)

--- a/src/Web/Slack/Channel.hs
+++ b/src/Web/Slack/Channel.hs
@@ -18,6 +18,9 @@ module Web.Slack.Channel
   , CreateReq(..)
   , mkCreateReq
   , CreateRsp(..)
+  , ListReq(..)
+  , mkListReq
+  , ListRsp(..)
   )
   where
 
@@ -50,10 +53,10 @@ data Channel =
     , channelIsArchived :: Bool
     , channelIsMember :: Bool
     , channelIsGeneral :: Bool
-    , channelLastRead :: Text
+    , channelLastRead :: Maybe Text
     , channelLatest :: Maybe Text
-    , channelUnreadCount :: Integer
-    , channelUnreadCountDisplay :: Integer
+    , channelUnreadCount :: Maybe Integer
+    , channelUnreadCountDisplay :: Maybe Integer
     , channelMembers :: [Text]
     , channelTopic :: Topic
     , channelPurpose :: Purpose
@@ -166,3 +169,61 @@ data CreateRsp =
 --
 --
 $(deriveJSON (jsonOpts "createRsp") ''CreateRsp)
+
+-- |
+--
+--
+
+data ListReq =
+  ListReq
+    { listReqExcludeArchived :: Maybe Bool
+    , listReqExcludeMembers :: Maybe Bool
+    }
+  deriving (Eq, Generic, Show)
+
+
+-- |
+--
+--
+
+$(deriveJSON (jsonOpts "listReq") ''ListReq)
+
+
+-- |
+--
+--
+
+instance ToForm ListReq where
+  toForm =
+    genericToForm (formOpts "listReq")
+
+
+-- |
+--
+--
+
+mkListReq
+  :: ListReq
+mkListReq =
+  ListReq
+    { listReqExcludeArchived = Nothing
+    , listReqExcludeMembers = Nothing
+    }
+
+
+-- |
+--
+--
+
+data ListRsp =
+  ListRsp
+    { listRspOk :: Bool
+    , listRspChannels :: [Channel]
+    }
+  deriving (Eq, Generic, Show)
+
+
+-- |
+--
+--
+$(deriveJSON (jsonOpts "listRsp") ''ListRsp)


### PR DESCRIPTION
add channel list to the API.

i had to make three existing fields in the channel type optional, because according to the slack apidocs..

> Some API methods (such as channels.join) will include extra state information for channels when the calling user is a member. last_read is the timestamp for the last message the calling user has read in this channel. unread_count is a full count of visible messages that the calling user has yet to read. unread_count_display is a count of messages that the calling user has yet to read that matter to them (this means it excludes things like join/leave messages). 

in other words some API methods will have these fields, others won't. for now I put them as `Maybe` but if we really want to be strict we could have two types: `Channel` and `ChannelExt`. What do you think?

Next on my list to add is channelHistory, that one takes a date range. I don't see a clear documentation for the "1401383885.000061" format in the slack apidocs, but I think it's a fractional number of seconds since 1970. I plan to expose that as a `UTCTime` type. Any thoughts?