### PR TITLE
timestamp bugfix+history fetchall

### DIFF
--- a/src/Web/Slack/Common.hs
+++ b/src/Web/Slack/Common.hs
@@ -67,8 +67,8 @@ data SlackTimestamp =
   deriving (Eq, Show)
 
 mkSlackTimestamp :: UTCTime -> SlackTimestamp
-mkSlackTimestamp utctime = SlackTimestamp (T.pack (show unixts) <> ".000000") utctime
-  where unixts = utcTimeToPOSIXSeconds utctime
+mkSlackTimestamp utctime = SlackTimestamp (T.pack (show @Integer unixts) <> ".000000") utctime
+  where unixts = floor $ toRational $ utcTimeToPOSIXSeconds utctime
 
 instance ToHttpApiData SlackTimestamp where
   toQueryParam (SlackTimestamp contents _) = contents

--- a/src/Web/Slack/Common.hs
+++ b/src/Web/Slack/Common.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE OverloadedLists #-}
 
 ----------------------------------------------------------------------
 -- |
@@ -110,8 +112,14 @@ $(deriveFromJSON (jsonOpts "historyReq") ''HistoryReq)
 --
 
 instance ToForm HistoryReq where
-  toForm =
-    genericToForm (formOpts "historyReq")
+  -- can't use genericToForm because slack expects booleans as 0/1
+  toForm HistoryReq{..} =
+      [ ("channel", toQueryParam historyReqChannel)
+      , ("count", toQueryParam historyReqCount)
+      , ("latest", toQueryParam historyReqLatest)
+      , ("oldest", toQueryParam historyReqOldest)
+      , ("inclusive", toQueryParam (if historyReqInclusive then 1::Int else 0))
+      ]
 
 
 -- |


### PR DESCRIPTION
little bugfix in timestamp handling (in its own commit).

in the second commit, added a higher-level function to fetch history: the REST functions provided by slack limit the row count of the response and give you back a boolean to let you know whether there are more records to fetch or not. the new function makes that loop transparently for the user.

i've hit an issue with our form serialization: the default `ToHttpApiData` for `Bool` serializes as `true` and `false`, unfortunately slack expects 0 or 1. In the specific case of 'inclusive' for the history request, if not present, slack assumes false. If we say 'false' then slack actually parses it as true... I don't see any other solution than creating a new type `SlackBool` with its own `ToHttpApiData` implementation, though it really feels ugly to export that to `slack-web` users. We could also have eg `InternalHistoryReq a`, export `HistoryReq = InternalHistoryReq Bool`, communicate with slack using `InternalHistoryReq SlackBool` and coerce between both versions... Any opinion? This is a little more general, because there will be many APIs taking boolean parameters.
As a temporary measure I've commented the 'inclusive' field in the request type, so that fixes the bug and lets the feature work.