### PR TITLE
Newstyle error handling

### DIFF
--- a/src/Web/Slack.hs
+++ b/src/Web/Slack.hs
@@ -377,23 +377,21 @@ historyFetchAll
   -> Text -> Int -> Common.SlackTimestamp -> Common.SlackTimestamp
   -> ClientM Common.HistoryRsp
 historyFetchAll token makeReq channel count oldest latest = do
-    rsp <- makeReq token (Common.HistoryReq channel count (Just latest) (Just oldest) False)
-    case rsp of
-      Common.HistoryRspError _ -> return rsp
-      Common.HistoryRsp msgs hasMore -> do
-        -- From slack apidoc: If there are more than 100 messages between
-        -- the two timestamps then the messages returned are the ones closest to latest.
-        -- In most cases an application will want the most recent messages
-        -- and will page backward from there.
-        --
-        -- for reference (does not apply here) => If oldest is provided but not
-        -- latest then the messages returned are those closest to oldest,
-        -- allowing you to page forward through history if desired.
-        let oldestReceived = Common.messageTs <$> lastZ msgs
-        if not hasMore || isNothing oldestReceived
-            then return rsp
-            else mergeResponses msgs <$>
-                 historyFetchAll token makeReq channel count oldest (fromJust oldestReceived)
+    rsp@(Common.HistoryRsp msgs hasMore) <-
+        makeReq token (Common.HistoryReq channel count (Just latest) (Just oldest) False)
+    -- From slack apidoc: If there are more than 100 messages between
+    -- the two timestamps then the messages returned are the ones closest to latest.
+    -- In most cases an application will want the most recent messages
+    -- and will page backward from there.
+    --
+    -- for reference (does not apply here) => If oldest is provided but not
+    -- latest then the messages returned are those closest to oldest,
+    -- allowing you to page forward through history if desired.
+    let oldestReceived = Common.messageTs <$> lastZ msgs
+    if not hasMore || isNothing oldestReceived
+        then return rsp
+        else mergeResponses msgs <$>
+             historyFetchAll token makeReq channel count oldest (fromJust oldestReceived)
 
 mergeResponses
   :: [Common.Message]

--- a/src/Web/Slack/Api.hs
+++ b/src/Web/Slack/Api.hs
@@ -20,7 +20,6 @@ module Web.Slack.Api
   where
 
 -- aeson
-import Data.Aeson
 import Data.Aeson.TH
 
 -- base
@@ -89,6 +88,4 @@ data TestRsp =
 -- |
 --
 --
-instance FromJSON TestRsp where
-  parseJSON = fromJsonWithOk "TestRsp" $ \o ->
-                TestRsp <$> o .: "args"
+$(deriveFromJSON (jsonOpts "testRsp") ''TestRsp)

--- a/src/Web/Slack/Api.hs
+++ b/src/Web/Slack/Api.hs
@@ -20,6 +20,7 @@ module Web.Slack.Api
   where
 
 -- aeson
+import Data.Aeson
 import Data.Aeson.TH
 
 -- base
@@ -79,16 +80,16 @@ mkTestReq =
 --
 --
 
-data TestRsp =
-  TestRsp
-    { testRspOk :: Bool
-    , testRspArgs :: Maybe TestReq
+data TestRsp
+  = TestRspError Text
+  | TestRsp
+    { testRspArgs :: Maybe TestReq
     }
   deriving (Eq, Generic, Show)
-
 
 -- |
 --
 --
-
-$(deriveJSON (jsonOpts "testRsp") ''TestRsp)
+instance FromJSON TestRsp where
+  parseJSON = fromJsonWithOk "TestRsp" TestRspError $ \o ->
+                TestRsp <$> o .: "args"

--- a/src/Web/Slack/Api.hs
+++ b/src/Web/Slack/Api.hs
@@ -80,9 +80,8 @@ mkTestReq =
 --
 --
 
-data TestRsp
-  = TestRspError Text
-  | TestRsp
+data TestRsp =
+  TestRsp
     { testRspArgs :: Maybe TestReq
     }
   deriving (Eq, Generic, Show)
@@ -91,5 +90,5 @@ data TestRsp
 --
 --
 instance FromJSON TestRsp where
-  parseJSON = fromJsonWithOk "TestRsp" TestRspError $ \o ->
+  parseJSON = fromJsonWithOk "TestRsp" $ \o ->
                 TestRsp <$> o .: "args"

--- a/src/Web/Slack/Auth.hs
+++ b/src/Web/Slack/Auth.hs
@@ -16,7 +16,7 @@ module Web.Slack.Auth
   where
 
 -- aeson
-import Data.Aeson.TH
+import Data.Aeson
 
 -- base
 import GHC.Generics (Generic)
@@ -32,10 +32,10 @@ import Data.Text (Text)
 --
 --
 
-data TestRsp =
-  TestRsp
-    { testRspOk :: Bool
-    , testRspUrl :: Text
+data TestRsp
+  = TestRspError Text
+  | TestRsp
+    { testRspUrl :: Text
     , testRspTeam :: Text
     , testRspUser :: Text
     , testRspTeamId :: Text
@@ -45,8 +45,8 @@ data TestRsp =
   deriving (Eq, Generic, Show)
 
 
--- |
---
---
-
-$(deriveJSON (jsonOpts "testRsp") ''TestRsp)
+instance FromJSON TestRsp where
+  parseJSON = fromJsonWithOk "TestRsp" TestRspError $ \o ->
+                TestRsp <$> o .: "url" <*> o .: "team" <*> o .: "user"
+                        <*> o .: "team_id" <*> o .: "user_id"
+                        <*> o .: "enterprise_id"

--- a/src/Web/Slack/Auth.hs
+++ b/src/Web/Slack/Auth.hs
@@ -32,9 +32,8 @@ import Data.Text (Text)
 --
 --
 
-data TestRsp
-  = TestRspError Text
-  | TestRsp
+data TestRsp =
+  TestRsp
     { testRspUrl :: Text
     , testRspTeam :: Text
     , testRspUser :: Text
@@ -46,7 +45,7 @@ data TestRsp
 
 
 instance FromJSON TestRsp where
-  parseJSON = fromJsonWithOk "TestRsp" TestRspError $ \o ->
+  parseJSON = fromJsonWithOk "TestRsp" $ \o ->
                 TestRsp <$> o .: "url" <*> o .: "team" <*> o .: "user"
                         <*> o .: "team_id" <*> o .: "user_id"
                         <*> o .: "enterprise_id"

--- a/src/Web/Slack/Auth.hs
+++ b/src/Web/Slack/Auth.hs
@@ -16,7 +16,7 @@ module Web.Slack.Auth
   where
 
 -- aeson
-import Data.Aeson
+import Data.Aeson.TH
 
 -- base
 import GHC.Generics (Generic)
@@ -44,8 +44,4 @@ data TestRsp =
   deriving (Eq, Generic, Show)
 
 
-instance FromJSON TestRsp where
-  parseJSON = fromJsonWithOk "TestRsp" $ \o ->
-                TestRsp <$> o .: "url" <*> o .: "team" <*> o .: "user"
-                        <*> o .: "team_id" <*> o .: "user_id"
-                        <*> o .: "enterprise_id"
+$(deriveJSON (jsonOpts "testRsp") ''TestRsp)

--- a/src/Web/Slack/Channel.hs
+++ b/src/Web/Slack/Channel.hs
@@ -25,7 +25,6 @@ module Web.Slack.Channel
   where
 
 -- aeson
-import Data.Aeson
 import Data.Aeson.TH
 
 -- base
@@ -168,9 +167,7 @@ data CreateRsp =
 -- |
 --
 --
-instance FromJSON CreateRsp where
-  parseJSON = fromJsonWithOk "CreateRsp" $ \o ->
-                CreateRsp <$> o .: "channel"
+$(deriveFromJSON (jsonOpts "createRsp") ''CreateRsp)
 
 data ListReq =
   ListReq
@@ -219,6 +216,4 @@ data ListRsp =
     }
   deriving (Eq, Generic, Show)
 
-instance FromJSON ListRsp where
-  parseJSON = fromJsonWithOk "ListRsp" $ \o ->
-                ListRsp <$> o .: "channels"
+$(deriveFromJSON (jsonOpts "listRsp") ''ListRsp)

--- a/src/Web/Slack/Channel.hs
+++ b/src/Web/Slack/Channel.hs
@@ -158,9 +158,8 @@ mkCreateReq name =
 --
 --
 
-data CreateRsp
-  = CreateRspError Text
-  | CreateRsp
+data CreateRsp =
+  CreateRsp
     { createRspChannel :: Channel
     }
   deriving (Eq, Generic, Show)
@@ -170,7 +169,7 @@ data CreateRsp
 --
 --
 instance FromJSON CreateRsp where
-  parseJSON = fromJsonWithOk "CreateRsp" CreateRspError $ \o ->
+  parseJSON = fromJsonWithOk "CreateRsp" $ \o ->
                 CreateRsp <$> o .: "channel"
 
 data ListReq =
@@ -214,13 +213,12 @@ mkListReq =
 --
 --
 
-data ListRsp
-  = ListRspError Text
-  | ListRsp
+data ListRsp =
+  ListRsp
     { listRspChannels :: [Channel]
     }
   deriving (Eq, Generic, Show)
 
 instance FromJSON ListRsp where
-  parseJSON = fromJsonWithOk "ListRsp" ListRspError $ \o ->
+  parseJSON = fromJsonWithOk "ListRsp" $ \o ->
                 ListRsp <$> o .: "channels"

--- a/src/Web/Slack/Channel.hs
+++ b/src/Web/Slack/Channel.hs
@@ -25,6 +25,7 @@ module Web.Slack.Channel
   where
 
 -- aeson
+import Data.Aeson
 import Data.Aeson.TH
 
 -- base
@@ -157,10 +158,10 @@ mkCreateReq name =
 --
 --
 
-data CreateRsp =
-  CreateRsp
-    { createRspOk :: Bool
-    , createRspChannel :: Channel
+data CreateRsp
+  = CreateRspError Text
+  | CreateRsp
+    { createRspChannel :: Channel
     }
   deriving (Eq, Generic, Show)
 
@@ -168,11 +169,9 @@ data CreateRsp =
 -- |
 --
 --
-$(deriveJSON (jsonOpts "createRsp") ''CreateRsp)
-
--- |
---
---
+instance FromJSON CreateRsp where
+  parseJSON = fromJsonWithOk "CreateRsp" CreateRspError $ \o ->
+                CreateRsp <$> o .: "channel"
 
 data ListReq =
   ListReq
@@ -215,15 +214,13 @@ mkListReq =
 --
 --
 
-data ListRsp =
-  ListRsp
-    { listRspOk :: Bool
-    , listRspChannels :: [Channel]
+data ListRsp
+  = ListRspError Text
+  | ListRsp
+    { listRspChannels :: [Channel]
     }
   deriving (Eq, Generic, Show)
 
-
--- |
---
---
-$(deriveJSON (jsonOpts "listRsp") ''ListRsp)
+instance FromJSON ListRsp where
+  parseJSON = fromJsonWithOk "ListRsp" ListRspError $ \o ->
+                ListRsp <$> o .: "channels"

--- a/src/Web/Slack/Chat.hs
+++ b/src/Web/Slack/Chat.hs
@@ -20,6 +20,7 @@ module Web.Slack.Chat
   where
 
 -- aeson
+import Data.Aeson
 import Data.Aeson.TH
 
 -- base
@@ -129,17 +130,14 @@ mkPostMsgReq channel text =
 --
 --
 
-data PostMsgRsp =
-  PostMsgRsp
-    { postMsgRspOk :: Bool
-    , postMsgRspTs :: String
+data PostMsgRsp
+  = PostMsgRspError Text
+  | PostMsgRsp
+    { postMsgRspTs :: String
     , postMsgRspMessage :: PostMsg
     }
   deriving (Eq, Generic, Show)
 
-
--- |
---
---
-
-$(deriveJSON (jsonOpts "postMsgRsp") ''PostMsgRsp)
+instance FromJSON PostMsgRsp where
+  parseJSON = fromJsonWithOk "PostMsgRsp" PostMsgRspError $ \o ->
+                PostMsgRsp <$> o .: "ts" <*> o .: "message"

--- a/src/Web/Slack/Chat.hs
+++ b/src/Web/Slack/Chat.hs
@@ -20,7 +20,6 @@ module Web.Slack.Chat
   where
 
 -- aeson
-import Data.Aeson
 import Data.Aeson.TH
 
 -- base
@@ -137,6 +136,4 @@ data PostMsgRsp =
     }
   deriving (Eq, Generic, Show)
 
-instance FromJSON PostMsgRsp where
-  parseJSON = fromJsonWithOk "PostMsgRsp" $ \o ->
-                PostMsgRsp <$> o .: "ts" <*> o .: "message"
+$(deriveFromJSON (jsonOpts "postMsgRsp") ''PostMsgRsp)

--- a/src/Web/Slack/Chat.hs
+++ b/src/Web/Slack/Chat.hs
@@ -130,14 +130,13 @@ mkPostMsgReq channel text =
 --
 --
 
-data PostMsgRsp
-  = PostMsgRspError Text
-  | PostMsgRsp
+data PostMsgRsp =
+  PostMsgRsp
     { postMsgRspTs :: String
     , postMsgRspMessage :: PostMsg
     }
   deriving (Eq, Generic, Show)
 
 instance FromJSON PostMsgRsp where
-  parseJSON = fromJsonWithOk "PostMsgRsp" PostMsgRspError $ \o ->
+  parseJSON = fromJsonWithOk "PostMsgRsp" $ \o ->
                 PostMsgRsp <$> o .: "ts" <*> o .: "message"

--- a/src/Web/Slack/Common.hs
+++ b/src/Web/Slack/Common.hs
@@ -155,14 +155,13 @@ data Message =
 
 $(deriveFromJSON (jsonOpts "message") ''Message)
 
-data HistoryRsp
-  = HistoryRspError Text
-  | HistoryRsp
+data HistoryRsp =
+  HistoryRsp
     { historyRspMessages :: [Message]
     , historyRspHasMore :: Bool
     }
   deriving (Eq, Generic, Show)
 
 instance FromJSON HistoryRsp where
-  parseJSON = fromJsonWithOk "HistoryRsp" HistoryRspError $ \o ->
+  parseJSON = fromJsonWithOk "HistoryRsp" $ \o ->
                 HistoryRsp <$> o .: "messages" <*> o .: "has_more"

--- a/src/Web/Slack/Common.hs
+++ b/src/Web/Slack/Common.hs
@@ -60,7 +60,6 @@ newtype Color = Color { unColor :: Text }
 newtype UserId = UserId { unUserId :: Text }
   deriving (Eq, Generic, Show, FromJSON)
 
-
 data SlackTimestamp =
   SlackTimestamp
     { slackTimestampTs :: Text
@@ -156,15 +155,14 @@ data Message =
 
 $(deriveFromJSON (jsonOpts "message") ''Message)
 
-data HistoryRsp =
-  HistoryRsp
-    { historyRspOk :: Bool
-    , historyRspMessages :: [Message]
+data HistoryRsp
+  = HistoryRspError Text
+  | HistoryRsp
+    { historyRspMessages :: [Message]
     , historyRspHasMore :: Bool
     }
   deriving (Eq, Generic, Show)
 
--- |
---
---
-$(deriveFromJSON (jsonOpts "historyRsp") ''HistoryRsp)
+instance FromJSON HistoryRsp where
+  parseJSON = fromJsonWithOk "HistoryRsp" HistoryRspError $ \o ->
+                HistoryRsp <$> o .: "messages" <*> o .: "has_more"

--- a/src/Web/Slack/Common.hs
+++ b/src/Web/Slack/Common.hs
@@ -24,6 +24,8 @@ module Web.Slack.Common
     , Message(..)
     , Color(unColor)
     , UserId(unUserId)
+    , SlackError(..)
+    , Response
     )
     where
 
@@ -162,6 +164,17 @@ data HistoryRsp =
     }
   deriving (Eq, Generic, Show)
 
-instance FromJSON HistoryRsp where
-  parseJSON = fromJsonWithOk "HistoryRsp" $ \o ->
-                HistoryRsp <$> o .: "messages" <*> o .: "has_more"
+$(deriveFromJSON (jsonOpts "historyRsp") ''HistoryRsp)
+
+-- |
+--
+--
+data SlackError = SlackError { slackErrorError :: Text }
+  deriving (Eq, Generic, Show)
+
+$(deriveFromJSON (jsonOpts "slackError") ''SlackError)
+
+-- |
+--
+--
+type Response a = Either SlackError a

--- a/src/Web/Slack/Group.hs
+++ b/src/Web/Slack/Group.hs
@@ -18,6 +18,7 @@ module Web.Slack.Group
   where
 
 -- aeson
+import Data.Aeson
 import Data.Aeson.TH
 
 -- base
@@ -46,11 +47,13 @@ data Group =
 
 $(deriveJSON (jsonOpts "group") ''Group)
 
-data ListRsp =
-  ListRsp
-    { listRspOk :: Bool
-    , listRspGroups :: [Group]
+data ListRsp
+  = ListRspError Text
+  | ListRsp
+    { listRspGroups :: [Group]
     }
   deriving (Eq, Generic, Show)
 
-$(deriveFromJSON (jsonOpts "listRsp") ''ListRsp)
+instance FromJSON ListRsp where
+  parseJSON = fromJsonWithOk "ListRsp" ListRspError $ \o ->
+                ListRsp <$> o .: "groups"

--- a/src/Web/Slack/Group.hs
+++ b/src/Web/Slack/Group.hs
@@ -47,13 +47,12 @@ data Group =
 
 $(deriveJSON (jsonOpts "group") ''Group)
 
-data ListRsp
-  = ListRspError Text
-  | ListRsp
+data ListRsp =
+  ListRsp
     { listRspGroups :: [Group]
     }
   deriving (Eq, Generic, Show)
 
 instance FromJSON ListRsp where
-  parseJSON = fromJsonWithOk "ListRsp" ListRspError $ \o ->
+  parseJSON = fromJsonWithOk "ListRsp" $ \o ->
                 ListRsp <$> o .: "groups"

--- a/src/Web/Slack/Group.hs
+++ b/src/Web/Slack/Group.hs
@@ -18,7 +18,6 @@ module Web.Slack.Group
   where
 
 -- aeson
-import Data.Aeson
 import Data.Aeson.TH
 
 -- base
@@ -53,6 +52,4 @@ data ListRsp =
     }
   deriving (Eq, Generic, Show)
 
-instance FromJSON ListRsp where
-  parseJSON = fromJsonWithOk "ListRsp" $ \o ->
-                ListRsp <$> o .: "groups"
+$(deriveFromJSON (jsonOpts "listRsp") ''ListRsp)

--- a/src/Web/Slack/Im.hs
+++ b/src/Web/Slack/Im.hs
@@ -47,13 +47,12 @@ data Im =
 
 $(deriveFromJSON (jsonOpts "im") ''Im)
 
-data ListRsp
-  = ListRspError Text
-  | ListRsp
+data ListRsp =
+  ListRsp
     { listRspIms :: [Im]
     }
   deriving (Eq, Generic, Show)
 
 instance FromJSON ListRsp where
-  parseJSON = fromJsonWithOk "ListRsp" ListRspError $ \o ->
+  parseJSON = fromJsonWithOk "ListRsp" $ \o ->
                 ListRsp <$> o .: "ims"

--- a/src/Web/Slack/Im.hs
+++ b/src/Web/Slack/Im.hs
@@ -19,6 +19,7 @@ module Web.Slack.Im
   where
 
 -- aeson
+import Data.Aeson
 import Data.Aeson.TH
 
 -- base
@@ -46,11 +47,13 @@ data Im =
 
 $(deriveFromJSON (jsonOpts "im") ''Im)
 
-data ListRsp =
-  ListRsp
-    { listRspOk :: Bool
-    , listRspIms :: [Im]
+data ListRsp
+  = ListRspError Text
+  | ListRsp
+    { listRspIms :: [Im]
     }
   deriving (Eq, Generic, Show)
 
-$(deriveFromJSON (jsonOpts "listRsp") ''ListRsp)
+instance FromJSON ListRsp where
+  parseJSON = fromJsonWithOk "ListRsp" ListRspError $ \o ->
+                ListRsp <$> o .: "ims"

--- a/src/Web/Slack/Im.hs
+++ b/src/Web/Slack/Im.hs
@@ -19,7 +19,6 @@ module Web.Slack.Im
   where
 
 -- aeson
-import Data.Aeson
 import Data.Aeson.TH
 
 -- base
@@ -53,6 +52,4 @@ data ListRsp =
     }
   deriving (Eq, Generic, Show)
 
-instance FromJSON ListRsp where
-  parseJSON = fromJsonWithOk "ListRsp" $ \o ->
-                ListRsp <$> o .: "ims"
+$(deriveFromJSON (jsonOpts "listRsp") ''ListRsp)

--- a/src/Web/Slack/User.hs
+++ b/src/Web/Slack/User.hs
@@ -51,13 +51,12 @@ data User =
 
 $(deriveFromJSON (jsonOpts "user") ''User)
 
-data ListRsp
-  = ListRspError Text
-  | ListRsp
+data ListRsp =
+  ListRsp
     { listRspMembers :: [User]
     }
   deriving (Eq, Generic, Show)
 
 instance FromJSON ListRsp where
-  parseJSON = fromJsonWithOk "ListRsp" ListRspError $ \o ->
+  parseJSON = fromJsonWithOk "ListRsp" $ \o ->
                 ListRsp <$> o .: "members"

--- a/src/Web/Slack/User.hs
+++ b/src/Web/Slack/User.hs
@@ -18,7 +18,6 @@ module Web.Slack.User
   where
 
 -- aeson
-import Data.Aeson
 import Data.Aeson.TH
 
 -- base
@@ -57,6 +56,4 @@ data ListRsp =
     }
   deriving (Eq, Generic, Show)
 
-instance FromJSON ListRsp where
-  parseJSON = fromJsonWithOk "ListRsp" $ \o ->
-                ListRsp <$> o .: "members"
+$(deriveFromJSON (jsonOpts "listRsp") ''ListRsp)

--- a/src/Web/Slack/User.hs
+++ b/src/Web/Slack/User.hs
@@ -18,6 +18,7 @@ module Web.Slack.User
   where
 
 -- aeson
+import Data.Aeson
 import Data.Aeson.TH
 
 -- base
@@ -50,11 +51,13 @@ data User =
 
 $(deriveFromJSON (jsonOpts "user") ''User)
 
-data ListRsp =
-  ListRsp
-    { listRspOk :: Bool
-    , listRspMembers :: [User]
+data ListRsp
+  = ListRspError Text
+  | ListRsp
+    { listRspMembers :: [User]
     }
   deriving (Eq, Generic, Show)
 
-$(deriveFromJSON (jsonOpts "listRsp") ''ListRsp)
+instance FromJSON ListRsp where
+  parseJSON = fromJsonWithOk "ListRsp" ListRspError $ \o ->
+                ListRsp <$> o .: "members"

--- a/src/Web/Slack/Util.hs
+++ b/src/Web/Slack/Util.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 ----------------------------------------------------------------------
 -- |
 -- Module: Web.Slack.Util
@@ -10,6 +12,7 @@
 module Web.Slack.Util
   ( formOpts
   , jsonOpts
+  , fromJsonWithOk
   )
   where
 
@@ -75,3 +78,10 @@ addUnderscores
   -> String
 addUnderscores =
   camelTo2 '_'
+
+fromJsonWithOk :: String -> (Text -> a) -> (Object -> Parser a) -> Value -> Parser a
+fromJsonWithOk objName errorCtor okReader = withObject objName $ \o -> do
+      ok <- o .: "ok"
+      if ok
+         then okReader o
+         else errorCtor <$> o .: "error"

--- a/src/Web/Slack/Util.hs
+++ b/src/Web/Slack/Util.hs
@@ -79,9 +79,9 @@ addUnderscores
 addUnderscores =
   camelTo2 '_'
 
-fromJsonWithOk :: String -> (Text -> a) -> (Object -> Parser a) -> Value -> Parser a
-fromJsonWithOk objName errorCtor okReader = withObject objName $ \o -> do
+fromJsonWithOk :: String -> (Object -> Parser a) -> Value -> Parser a
+fromJsonWithOk objName okReader = withObject objName $ \o -> do
       ok <- o .: "ok"
       if ok
          then okReader o
-         else errorCtor <$> o .: "error"
+         else fail =<< o .: "error"

--- a/src/Web/Slack/Util.hs
+++ b/src/Web/Slack/Util.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 ----------------------------------------------------------------------
 -- |
 -- Module: Web.Slack.Util
@@ -12,7 +10,6 @@
 module Web.Slack.Util
   ( formOpts
   , jsonOpts
-  , fromJsonWithOk
   )
   where
 
@@ -78,10 +75,3 @@ addUnderscores
   -> String
 addUnderscores =
   camelTo2 '_'
-
-fromJsonWithOk :: String -> (Object -> Parser a) -> Value -> Parser a
-fromJsonWithOk objName okReader = withObject objName $ \o -> do
-      ok <- o .: "ok"
-      if ok
-         then okReader o
-         else fail =<< o .: "error"


### PR DESCRIPTION
so just about every response slack returns something like

    { "ok": true,  ... }

and currently we expose that to users of the library. They are supposed to check for every call they make that `ok` is really true, and otherwise read the `error` field and so on.

so i've implemented two alternatives, a commit for each. in the first version, instead of...

    data CallResp = CallResp { ok :: Bool, ... }

we now have:

    data CallResp = CallRespError Text | CallResp { ... }

and with the second option, we have:

    data CallResp = CallResp { ... }

With the second option what I do is use `fail` within `parseJSON`. In a way, that could be controversial because you could get a failure in decoding then out of two reasons: invalid JSON from the server (like corrupted or truncated, OR the JSON was valid, but `ok` was false.

Here's what I found in the aeson docs:

> There are various reasons a conversion could fail. For example, an Object could be missing a required key, an Array could be of the wrong size, or a value could be of an incompatible type.

> fail yields a custom error message;

It does not really support this use of it that I'm doing now, but it doesn't really condemn it either... Now, I prefer the second solution. It more concise and more handy for the user of the library. Users get many useful functions to work with `Either` out of the box, while the alternative is a custom type for each API call. But I'm pushing both commits so you get the idea.

Here is an example of what you get on error with the second solution by the way:

    Left (DecodeFailure {decodeError = "Error in $: channel_not_found", responseContentType = application/json;charset=utf-8, responseBody = "{\"ok\":false,\"error\":\"channel_not_found\"}"})

If it's my call, I'd squash both commits, push only the `fail` solution in a single commit to master. But maybe you think otherwise or see a third way?