### PR TITLE
unexport the util module

### DIFF
--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -39,6 +39,7 @@ library
       Web.Slack.Group
       Web.Slack.Im
       Web.Slack.User
+  other-modules:
       Web.Slack.Util
   build-depends:
       aeson >= 1.0 && < 1.2


### PR DESCRIPTION
i don't think the 'Util' module was meant to be exported? (exports the formOpts and jsonOpts functions)