### PR TITLE
add Ord instances for UserId, Color and SlackTimestamp.

### DIFF
--- a/src/Web/Slack/Common.hs
+++ b/src/Web/Slack/Common.hs
@@ -57,10 +57,10 @@ import Data.Time.Clock
 import Data.Time.Clock.POSIX
 
 newtype Color = Color { unColor :: Text }
-  deriving (Eq, Generic, Show, FromJSON)
+  deriving (Eq, Ord, Generic, Show, FromJSON)
 
 newtype UserId = UserId { unUserId :: Text }
-  deriving (Eq, Generic, Show, FromJSON)
+  deriving (Eq, Ord, Generic, Show, FromJSON)
 
 data SlackTimestamp =
   SlackTimestamp
@@ -68,6 +68,9 @@ data SlackTimestamp =
     , slackTimestampTime :: UTCTime
     }
   deriving (Eq, Show)
+
+instance Ord SlackTimestamp where
+    compare (SlackTimestamp _ a) (SlackTimestamp _ b) = compare a b
 
 mkSlackTimestamp :: UTCTime -> SlackTimestamp
 mkSlackTimestamp utctime = SlackTimestamp (T.pack (show @Integer unixts) <> ".000000") utctime


### PR DESCRIPTION
it's pretty clear why one would want an ord instance for SlackTimestamp (sorting), but i actually needed the one for UserId, so I could use it as a key in a `Map` (which is a treemap behind the scenes, so it needs ordering). It's pretty natural to build a `Map UserId Text` from user id to username.