### PR TITLE
more uses of UserId instead of Text

### DIFF
--- a/src/Web/Slack/Channel.hs
+++ b/src/Web/Slack/Channel.hs
@@ -34,6 +34,7 @@ import GHC.Generics (Generic)
 import Web.FormUrlEncoded
 
 -- slack-web
+import Web.Slack.Common
 import Web.Slack.Util
 
 -- text
@@ -49,7 +50,7 @@ data Channel =
     { channelId :: Text
     , channelName :: Text
     , channelCreated :: Integer
-    , channelCreator :: Text
+    , channelCreator :: UserId
     , channelIsArchived :: Bool
     , channelIsMember :: Bool
     , channelIsGeneral :: Bool
@@ -57,7 +58,7 @@ data Channel =
     , channelLatest :: Maybe Text
     , channelUnreadCount :: Maybe Integer
     , channelUnreadCountDisplay :: Maybe Integer
-    , channelMembers :: [Text]
+    , channelMembers :: [UserId]
     , channelTopic :: Topic
     , channelPurpose :: Purpose
     }
@@ -94,7 +95,7 @@ data Topic =
 --
 --
 
-$(deriveJSON (jsonOpts "channel") ''Channel)
+$(deriveFromJSON (jsonOpts "channel") ''Channel)
 
 
 -- |

--- a/src/Web/Slack/Group.hs
+++ b/src/Web/Slack/Group.hs
@@ -24,6 +24,7 @@ import Data.Aeson.TH
 import GHC.Generics (Generic)
 
 -- slack-web
+import Web.Slack.Common
 import Web.Slack.Util
 
 -- text
@@ -38,13 +39,13 @@ data Group =
     , groupName :: Text
     , groupIsMpim :: Bool
     , groupCreated :: POSIXTime
-    , groupCreator :: Text
+    , groupCreator :: UserId
     , groupIsArchived :: Bool
-    , groupMembers :: [Text]
+    , groupMembers :: [UserId]
     }
   deriving (Eq, Generic, Show)
 
-$(deriveJSON (jsonOpts "group") ''Group)
+$(deriveFromJSON (jsonOpts "group") ''Group)
 
 data ListRsp =
   ListRsp


### PR DESCRIPTION
correctly use the type `UserId` in a couple more cases.