### PR TITLE
don't return an either of either to the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,24 @@
 ```
 
 ```
-> manager <- Slack.mkManager
-```
-
-```
-> Slack.run manager (Slack.apiTest Api.mkTestReq)
-Right ...
+> import Control.Monad.Reader
 ```
 
 ```
 > :set -XOverloadedStrings
-> Slack.run manager (Slack.apiTest Api.mkTestReq { Api.testReqFoo = Just "bar" })
+```
+
+```
+> slackConfig <- Slack.mkSlackConfig token
+```
+
+```
+> flip runReaderT slackConfig (Slack.apiTest Api.mkTestReq)
+Right ...
+```
+
+```
+> flip runReaderT slackConfig (Slack.apiTest Api.mkTestReq { Api.testReqFoo = Just "bar" })
 Right ...
 ```
 

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -51,6 +51,7 @@ library
     , servant-client >= 0.9 && < 0.11
     , text >= 1.2 && < 1.3
     , transformers
+    , mtl
     , time
     , errors
   default-language:

--- a/src/Web/Slack/Common.hs
+++ b/src/Web/Slack/Common.hs
@@ -24,9 +24,7 @@ module Web.Slack.Common
     , Message(..)
     , Color(unColor)
     , UserId(unUserId)
-    , SlackError(..)
     , SlackClientError(..)
-    , Response
     )
     where
 
@@ -174,17 +172,10 @@ data HistoryRsp =
 $(deriveFromJSON (jsonOpts "historyRsp") ''HistoryRsp)
 
 -- |
---
---
-data SlackError = SlackError { slackErrorError :: Text }
+-- Errors that can be triggered by a slack request.
+data SlackClientError
+    = ServantError ServantError
+    -- ^ errors from the network connection
+    | SlackError Text
+    -- ^ errors returned by the slack API
   deriving (Eq, Generic, Show)
-
-$(deriveFromJSON (jsonOpts "slackError") ''SlackError)
-
--- |
---
---
-data SlackClientError = ServantError ServantError | SlackCallError SlackError
-  deriving (Eq, Generic, Show)
-
-type Response a = Either SlackError a

--- a/src/Web/Slack/Common.hs
+++ b/src/Web/Slack/Common.hs
@@ -25,6 +25,7 @@ module Web.Slack.Common
     , Color(unColor)
     , UserId(unUserId)
     , SlackError(..)
+    , SlackClientError(..)
     , Response
     )
     where
@@ -43,6 +44,9 @@ import Control.Error (hush)
 -- http-api-data
 import Web.FormUrlEncoded
 import Web.HttpApiData
+
+-- servant-client
+import Servant.Common.Req
 
 -- slack-web
 import Web.Slack.Util
@@ -180,4 +184,7 @@ $(deriveFromJSON (jsonOpts "slackError") ''SlackError)
 -- |
 --
 --
+data SlackClientError = ServantError ServantError | SlackCallError SlackError
+  deriving (Eq, Generic, Show)
+
 type Response a = Either SlackError a


### PR DESCRIPTION
since we've redone the error handling, it annoyed me a lot that we returned an `Either ServantError (Either SlackError a)` to the user.
In this PR, i define an `unnestErrors` function which in effect we were forcing the user of the library to define.

I much prefer this now, interested in your thoughts, and also maybe you have some thoughts regarding the type & type constructors naming?

```haskell
data SlackClientError = ServantError ServantError | SlackCallError SlackError
```

SlackClientError, SlackError, SlackCallError... I'm not really proud of those, don't have much better ideas right now though.