### PR TITLE
message parsing: RFC

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,3 +14,4 @@ test:
   override:
     - stack build
     - stack build --resolver lts-8.3
+    - stack test

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -61,6 +61,23 @@ library
   ghc-options:
       -Wall
 
+test-suite tests
+  main-is:
+      Spec.hs
+  hs-source-dirs:
+       tests
+  type:
+       exitcode-stdio-1.0
+  other-modules:
+       Web.Slack.MessageParserSpec
+  build-depends:
+      base >= 4.9 && < 4.10
+    , hspec
+    , slack-web
+  default-language:
+    Haskell2010
+  ghc-options:
+       -Wall
 
 source-repository head
   type: git

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -39,6 +39,7 @@ library
       Web.Slack.Group
       Web.Slack.Im
       Web.Slack.User
+      Web.Slack.MessageParser
   other-modules:
       Web.Slack.Util
   build-depends:
@@ -54,6 +55,7 @@ library
     , mtl
     , time
     , errors
+    , megaparsec
   default-language:
       Haskell2010
   ghc-options:

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -39,8 +39,8 @@ library
       Web.Slack.Group
       Web.Slack.Im
       Web.Slack.User
-      Web.Slack.MessageParser
   other-modules:
+      Web.Slack.MessageParser
       Web.Slack.Util
   build-depends:
       aeson >= 1.0 && < 1.2
@@ -61,19 +61,24 @@ library
   ghc-options:
       -Wall
 
+-- the test suite doesn't depend on slack-web
+-- but rather has the src as an extra source directory.
+-- that allows us to refer to non exported modules from tests.
 test-suite tests
   main-is:
       Spec.hs
   hs-source-dirs:
-       tests
+       src, tests
   type:
        exitcode-stdio-1.0
   other-modules:
+       Web.Slack.MessageParser
        Web.Slack.MessageParserSpec
   build-depends:
       base >= 4.9 && < 4.10
     , hspec
-    , slack-web
+    , text
+    , megaparsec
   default-language:
     Haskell2010
   ghc-options:

--- a/src/Web/Slack/Common.hs
+++ b/src/Web/Slack/Common.hs
@@ -166,7 +166,7 @@ instance FromJSON Message where
   parseJSON = withObject "Message" $ \o -> do
     Message
         <$> o .: "type"
-        <*> o .: "user"
+        <*> o .:? "user"
         <*> o .: "text"
         <*> (messageToHtml <$> o .: "text")
         <*> o .: "ts"

--- a/src/Web/Slack/MessageParser.hs
+++ b/src/Web/Slack/MessageParser.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | See https://api.slack.com/docs/message-formatting
+--
+module Web.Slack.MessageParser
+  ( parseMessage
+  , SlackMsgItem(..)
+  , SlackUrl(..)
+  , messageToHtml
+  )
+  where
+
+import Control.Monad
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.Maybe
+import Data.Monoid
+import Data.Functor.Identity
+import Text.Megaparsec
+import Control.Monad.Trans.State
+
+newtype SlackUrl = SlackUrl { unSlackUrl :: Text }
+  deriving (Show, Eq)
+
+data SlackMsgItem
+  = SlackMsgItemPlainText
+     { slackPlainTextBold :: Bool
+     , slackPlainTextItalics :: Bool
+     , slackPlainTextText :: Text
+     }
+  | SlackMsgItemLink Text SlackUrl
+  | SlackMsgItemInlineCodeSection Text
+  | SlackMsgItemCodeSection Text
+  | SlackMsgItemQuoted [SlackMsgItem]
+  | SlackMsgItemSymbol Text
+  deriving (Show, Eq)
+
+data SlackParserState = SlackParserState
+  { slackParserStateBoldText :: Bool
+  , slackParserStateItalicsText :: Bool
+  }
+
+initialSlackParserState :: SlackParserState
+initialSlackParserState = SlackParserState False False
+
+type SlackParser a = StateT SlackParserState (ParsecT Dec T.Text Identity) a
+
+parseMessage :: Text -> [SlackMsgItem]
+parseMessage input = fromMaybe [SlackMsgItemPlainText False False input] $
+  fst <$> parseMaybe (runStateT (many parseMessageItem) initialSlackParserState) input
+
+parseMessageItem :: SlackParser SlackMsgItem
+parseMessageItem
+  = parsePlainText
+  <|> (char '*' >> modify (\st -> st { slackParserStateBoldText = not (slackParserStateBoldText st) }) >> pure (SlackMsgItemSymbol "*"))
+  <|> (char '_' >> modify (\st -> st { slackParserStateItalicsText = not (slackParserStateItalicsText st) }) >> pure (SlackMsgItemSymbol "_"))
+  <|> parseLink
+
+parsePlainText :: SlackParser SlackMsgItem
+parsePlainText = do
+  st <- get
+  SlackMsgItemPlainText
+    (slackParserStateBoldText st) (slackParserStateItalicsText st) . T.pack <$>
+    some (noneOf ['<', '`', '*', '_'])
+
+parseLink :: SlackParser SlackMsgItem
+parseLink = do
+    void (char '<')
+    url <- SlackUrl . T.pack <$> some (noneOf ['|', '>'])
+    let linkWithoutDesc = char '>' >> pure (SlackMsgItemLink (unSlackUrl url) url)
+    let linkWithDesc = char '|' >> SlackMsgItemLink <$> ((T.pack <$> some (noneOf ['>'])) <* char '>') <*> pure url
+    linkWithDesc <|> linkWithoutDesc
+
+messageToHtml :: Text -> Text
+messageToHtml = messageToHtml' . parseMessage
+
+messageToHtml' :: [SlackMsgItem] -> Text
+messageToHtml' = foldr ((<>) . msgItemToHtml) ""
+
+msgItemToHtml :: SlackMsgItem -> Text
+msgItemToHtml (SlackMsgItemPlainText True True txt) = "<b><i>" <> txt <> "</i></b>"
+msgItemToHtml (SlackMsgItemPlainText True False txt) = "<b>" <> txt <> "</b>"
+msgItemToHtml (SlackMsgItemPlainText False True txt) = "<i>" <> txt <> "</i>"
+msgItemToHtml (SlackMsgItemPlainText False False txt) = txt
+msgItemToHtml (SlackMsgItemLink txt url) = "<a href='" <> unSlackUrl url <> "'>" <> txt <> "</a>"
+msgItemToHtml (SlackMsgItemInlineCodeSection code) = "<pre>" <> code <> "</code>"
+msgItemToHtml (SlackMsgItemCodeSection code) = "<pre>" <> code <> "</code>"
+msgItemToHtml (SlackMsgItemQuoted items) = "<blockquote>" <> messageToHtml' items <> "</blockquote>"
+msgItemToHtml (SlackMsgItemSymbol _) = ""

--- a/src/Web/Slack/MessageParser.hs
+++ b/src/Web/Slack/MessageParser.hs
@@ -11,14 +11,21 @@ module Web.Slack.MessageParser
   )
   where
 
+-- base
 import Control.Monad
-import Data.Text (Text)
-import qualified Data.Text as T
 import Data.Maybe
 import Data.Monoid
-import Data.Functor.Identity
+
+-- megaparsec
 import Text.Megaparsec
+
+-- mtl
+import Data.Functor.Identity
 import Control.Monad.Trans.State
+
+-- text
+import Data.Text (Text)
+import qualified Data.Text as T
 
 newtype SlackUrl = SlackUrl { unSlackUrl :: Text }
   deriving (Show, Eq)

--- a/src/Web/Slack/MessageParser.hs
+++ b/src/Web/Slack/MessageParser.hs
@@ -90,7 +90,7 @@ parseLink = do
   linkWithDesc <|> linkWithoutDesc
 
 parseCode :: SlackParser SlackMsgItem
-parseCode = SlackMsgItemInlineCodeSection . T.pack <$>
+parseCode = SlackMsgItemCodeSection . T.pack <$>
   (string "```" >> manyTill anyChar (string "```"))
 
 parseInlineCode :: SlackParser SlackMsgItem
@@ -99,7 +99,7 @@ parseInlineCode = SlackMsgItemInlineCodeSection . T.pack <$>
 
 parseBlockQuote :: SlackParser SlackMsgItem
 parseBlockQuote = SlackMsgItemQuoted <$>
-  (char '>' *> optional (char ' ') *> some parseMessageItem)
+  (string "&gt;" *> optional (char ' ') *> some parseMessageItem)
 
 messageToHtml :: Text -> Text
 messageToHtml = messageToHtml' . parseMessage

--- a/src/Web/Slack/MessageParser.hs
+++ b/src/Web/Slack/MessageParser.hs
@@ -113,6 +113,6 @@ msgItemToHtml = \case
   SlackMsgItemBoldSection cts -> "<b>" <> messageToHtml' cts <> "</b>"
   SlackMsgItemItalicsSection cts -> "<i>" <> messageToHtml' cts <> "</i>"
   SlackMsgItemLink txt url -> "<a href='" <> unSlackUrl url <> "'>" <> txt <> "</a>"
-  SlackMsgItemInlineCodeSection code -> "<pre>" <> code <> "</pre>"
+  SlackMsgItemInlineCodeSection code -> "<code>" <> code <> "</code>"
   SlackMsgItemCodeSection code -> "<pre>" <> code <> "</pre>"
   SlackMsgItemQuoted items -> "<blockquote>" <> messageToHtml' items <> "</blockquote>"

--- a/src/Web/Slack/MessageParser.hs
+++ b/src/Web/Slack/MessageParser.hs
@@ -70,12 +70,13 @@ parseWhitespace True = SlackMsgItemPlainText . T.pack <$> some (oneOf [' ', '\n'
 parseWhitespace False = SlackMsgItemPlainText . T.pack <$> some (oneOf [' '])
 
 boldEndSymbol :: SlackParser ()
-boldEndSymbol = void $ char '*' >>
-    lookAhead (void (oneOf [' ', '\n', '_']) <|> eof)
+boldEndSymbol = void $ char '*' >> lookAhead wordBoundary
 
 italicsEndSymbol :: SlackParser ()
-italicsEndSymbol = void $ char '_' >>
-    lookAhead (void (oneOf [' ', '\n', '*']) <|> eof)
+italicsEndSymbol = void $ char '_' >> lookAhead wordBoundary
+
+wordBoundary :: SlackParser ()
+wordBoundary = void (oneOf [' ', '\n', '*', '_', ',', '`', '?', '!', ':', ';']) <|> eof
 
 parseBoldSection :: SlackParser SlackMsgItem
 parseBoldSection = fmap SlackMsgItemBoldSection $

--- a/src/Web/Slack/MessageParser.hs
+++ b/src/Web/Slack/MessageParser.hs
@@ -55,9 +55,9 @@ parseMessageItem
 
 parsePlainText :: SlackParser SlackMsgItem
 parsePlainText = SlackMsgItemPlainText . T.pack <$>
-    someTill (noneOf stopChars) (void (lookAhead $ oneOf stopChars)
-                                   <|> lookAhead boldEndSymbol
-                                   <|> lookAhead italicsEndSymbol
+    someTill (noneOf stopChars) (void (lookAhead $ try $ oneOf stopChars)
+                                   <|> lookAhead (try boldEndSymbol)
+                                   <|> lookAhead (try italicsEndSymbol)
                                    <|> lookAhead eof)
     where stopChars = [' ', '\n']
 

--- a/src/Web/Slack/MessageParser.hs
+++ b/src/Web/Slack/MessageParser.hs
@@ -68,10 +68,12 @@ parseWhitespace :: SlackParser SlackMsgItem
 parseWhitespace = SlackMsgItemPlainText . T.pack <$> some (oneOf [' ', '\n'])
 
 boldEndSymbol :: SlackParser ()
-boldEndSymbol = void $ char '*' >> lookAhead (void (oneOf [' ', '\n', '_']) <|> eof)
+boldEndSymbol = void $ char '*' >>
+    lookAhead (void (oneOf [' ', '\n', '_']) <|> eof)
 
 italicsEndSymbol :: SlackParser ()
-italicsEndSymbol = void $ char '_' >> lookAhead (void (oneOf [' ', '\n', '*']) <|> eof)
+italicsEndSymbol = void $ char '_' >>
+    lookAhead (void (oneOf [' ', '\n', '*']) <|> eof)
 
 parseBoldSection :: SlackParser SlackMsgItem
 parseBoldSection = fmap SlackMsgItemBoldSection $
@@ -85,8 +87,10 @@ parseLink :: SlackParser SlackMsgItem
 parseLink = do
   void (char '<')
   url <- SlackUrl . T.pack <$> some (noneOf ['|', '>'])
-  let linkWithoutDesc = char '>' >> pure (SlackMsgItemLink (unSlackUrl url) url)
-  let linkWithDesc = char '|' >> SlackMsgItemLink <$> ((T.pack <$> some (noneOf ['>'])) <* char '>') <*> pure url
+  let linkWithoutDesc = char '>' >>
+          pure (SlackMsgItemLink (unSlackUrl url) url)
+  let linkWithDesc = char '|' >>
+          SlackMsgItemLink <$> ((T.pack <$> some (noneOf ['>'])) <* char '>') <*> pure url
   linkWithDesc <|> linkWithoutDesc
 
 parseCode :: SlackParser SlackMsgItem

--- a/tests/Spec.hs
+++ b/tests/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/tests/Web/Slack/MessageParserSpec.hs
+++ b/tests/Web/Slack/MessageParserSpec.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Web.Slack.MessageParserSpec (spec) where
+
+-- hspec
+import Test.Hspec
+
+-- slack-web
+import Web.Slack.MessageParser
+
+spec :: Spec
+spec = do
+  describe "message contents parsing" $ do
+    it "converts a simple message to HTML correctly" $
+      messageToHtml "hel_lo *world_* <http://www.google.com|google> `code` ```longer\ncode```"
+        `shouldBe`
+        "hel<i>lo </i><b><i>world</i></b> <a href='http://www.google.com'>google</a> <pre>code</pre> <pre>longer\ncode</pre>"
+    it "degrades properly to return the input message if it's incorrect" $
+      messageToHtml "link not closed <bad"
+        `shouldBe`
+        "link not closed <bad"

--- a/tests/Web/Slack/MessageParserSpec.hs
+++ b/tests/Web/Slack/MessageParserSpec.hs
@@ -11,6 +11,8 @@ import Web.Slack.MessageParser
 spec :: Spec
 spec =
   describe "message contents parsing" $ do
+    it "handles the trivial case well" $
+      messageToHtml "hello" `shouldBe` "hello"
     it "converts a simple message to HTML correctly" $
       messageToHtml "_hello_ *world* <http://www.google.com|google> `code` ```longer\ncode```"
         `shouldBe`
@@ -25,3 +27,7 @@ spec =
       messageToHtml "*_both_*" `shouldBe` "<b><i>both</i></b>"
     it "aborts nicely on interspersed bold & italics" $
       messageToHtml "inter *sper_ *sed_" `shouldBe` "inter *sper_ *sed_"
+    it "parses blockquotes properly" $
+      messageToHtml "look at this:\n> test *wow*" `shouldBe` "look at this:\n<blockquote>test <b>wow</b></blockquote>"
+    it "parses code blocks properly" $
+      messageToHtml "look at this:\n```test *wow*```" `shouldBe` "look at this:\n<pre>test *wow*</pre>"

--- a/tests/Web/Slack/MessageParserSpec.hs
+++ b/tests/Web/Slack/MessageParserSpec.hs
@@ -31,3 +31,8 @@ spec =
       messageToHtml "look at this:\n&gt; test *wow*" `shouldBe` "look at this:\n<blockquote>test <b>wow</b></blockquote>"
     it "parses code blocks properly" $
       messageToHtml "look at this:\n```test *wow*```" `shouldBe` "look at this:\n<pre>test *wow*</pre>"
+    it "handles non-italics underscores in text well" $
+      -- need to put other HTML symbols, otherwise if the parsing fails
+      -- i won't find out since we default to returning the input on
+      -- parsing failure
+      messageToHtml "a:\n&gt;b.\n:slightly_smiling_face:" `shouldBe` "a:\n<blockquote>b.\n:slightly_smiling_face:</blockquote>"

--- a/tests/Web/Slack/MessageParserSpec.hs
+++ b/tests/Web/Slack/MessageParserSpec.hs
@@ -9,13 +9,19 @@ import Test.Hspec
 import Web.Slack.MessageParser
 
 spec :: Spec
-spec = do
+spec =
   describe "message contents parsing" $ do
     it "converts a simple message to HTML correctly" $
-      messageToHtml "hel_lo *world_* <http://www.google.com|google> `code` ```longer\ncode```"
+      messageToHtml "_hello_ *world* <http://www.google.com|google> `code` ```longer\ncode```"
         `shouldBe`
-        "hel<i>lo </i><b><i>world</i></b> <a href='http://www.google.com'>google</a> <pre>code</pre> <pre>longer\ncode</pre>"
+        "<i>hello</i> <b>world</b> <a href='http://www.google.com'>google</a> <pre>code</pre> <pre>longer\ncode</pre>"
     it "degrades properly to return the input message if it's incorrect" $
       messageToHtml "link not closed <bad"
         `shouldBe`
         "link not closed <bad"
+    it "creates italics sections only at word boundaries" $
+      messageToHtml "false_positive" `shouldBe` "false_positive"
+    it "handles bold & italics simultaneously" $
+      messageToHtml "*_both_*" `shouldBe` "<b><i>both</i></b>"
+    it "aborts nicely on interspersed bold & italics" $
+      messageToHtml "inter *sper_ *sed_" `shouldBe` "inter *sper_ *sed_"

--- a/tests/Web/Slack/MessageParserSpec.hs
+++ b/tests/Web/Slack/MessageParserSpec.hs
@@ -35,4 +35,8 @@ spec =
       -- need to put other HTML symbols, otherwise if the parsing fails
       -- i won't find out since we default to returning the input on
       -- parsing failure
-      messageToHtml "a:\n&gt;b.\n:slightly_smiling_face:" `shouldBe` "a:\n<blockquote>b.\n:slightly_smiling_face:</blockquote>"
+      messageToHtml "a:\n&gt;b.\n:slightly_smiling_face:" `shouldBe` "a:\n<blockquote>b.</blockquote>:slightly_smiling_face:"
+    it "properly parses multiline blockquotes" $
+      messageToHtml "&gt; first row\n&gt; second row\nthird row\n&gt; fourth row"
+        `shouldBe`
+        "<blockquote>first row<br/>second row</blockquote>third row\n<blockquote>fourth row</blockquote>"

--- a/tests/Web/Slack/MessageParserSpec.hs
+++ b/tests/Web/Slack/MessageParserSpec.hs
@@ -16,7 +16,7 @@ spec =
     it "converts a simple message to HTML correctly" $
       messageToHtml "_hello_ *world* <http://www.google.com|google> `code` ```longer\ncode```"
         `shouldBe`
-        "<i>hello</i> <b>world</b> <a href='http://www.google.com'>google</a> <pre>code</pre> <pre>longer\ncode</pre>"
+        "<i>hello</i> <b>world</b> <a href='http://www.google.com'>google</a> <code>code</code> <pre>longer\ncode</pre>"
     it "degrades properly to return the input message if it's incorrect" $
       messageToHtml "link not closed <bad"
         `shouldBe`
@@ -28,6 +28,6 @@ spec =
     it "aborts nicely on interspersed bold & italics" $
       messageToHtml "inter *sper_ *sed_" `shouldBe` "inter *sper_ *sed_"
     it "parses blockquotes properly" $
-      messageToHtml "look at this:\n> test *wow*" `shouldBe` "look at this:\n<blockquote>test <b>wow</b></blockquote>"
+      messageToHtml "look at this:\n&gt; test *wow*" `shouldBe` "look at this:\n<blockquote>test <b>wow</b></blockquote>"
     it "parses code blocks properly" $
       messageToHtml "look at this:\n```test *wow*```" `shouldBe` "look at this:\n<pre>test *wow*</pre>"


### PR DESCRIPTION
so i noticed that the message contents that we get from slack are not HTML. they'e some sort of markdown, but not quite markdown. it's documented there: https://api.slack.com/docs/message-formatting

In particular, I think `<url|desc>` is just not valid markdown...

and well, i have something with parsing, i just like it :-)

so i started writing a parser for that, plus a converter to html. now, this brings in the megaparsec dependency, there's a real question as to whether this really fits in `slack-web`. I don't mind whether this goes in slack-web or not, really. I'm happy with having this in my app.
And if we want it in, we still have two options: export the AST for the messages (`SlackMsgItem`), or just export the converter to HTML. Maybe the latter is the most reasonnable, again if we include this at all.

So this is just a request for comment: do you think this makes sense within slack-web? And if yes, do you agree with megaparsec for the implementation?

obviously this is just a first draft: i need to add tests, finish it and so on. So in any case, I don't want this pulled in its current state: this is just a request for comment.