### PR TITLE
decoding of usernames in chat message body, more exports, more apidocs

### DIFF
--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -38,13 +38,15 @@ library
       Web.Slack.Common
       Web.Slack.Group
       Web.Slack.Im
+      Web.Slack.MessageParser
       Web.Slack.User
   other-modules:
-      Web.Slack.MessageParser
+      Web.Slack.Types
       Web.Slack.Util
   build-depends:
       aeson >= 1.0 && < 1.2
     , base >= 4.9 && < 4.10
+    , containers
     , http-api-data >= 0.3 && < 0.4
     , http-client >= 0.5 && < 0.6
     , http-client-tls >= 0.3 && < 0.4
@@ -68,16 +70,22 @@ test-suite tests
   main-is:
       Spec.hs
   hs-source-dirs:
-       src, tests
+      src, tests
   type:
-       exitcode-stdio-1.0
+      exitcode-stdio-1.0
   other-modules:
-       Web.Slack.MessageParser
-       Web.Slack.MessageParserSpec
+      Web.Slack.MessageParser
+      Web.Slack.MessageParserSpec
+      Web.Slack.Types
   build-depends:
       base >= 4.9 && < 4.10
+    , containers
+    , aeson
+    , errors
     , hspec
+    , http-api-data
     , text
+    , time
     , megaparsec
   default-language:
     Haskell2010

--- a/src/Web/Slack/Types.hs
+++ b/src/Web/Slack/Types.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+
+----------------------------------------------------------------------
+-- |
+-- Module: Web.Slack.Types
+-- Description:
+--
+--
+--
+----------------------------------------------------------------------
+
+module Web.Slack.Types
+  ( Color(..)
+  , UserId(..)
+  , SlackTimestamp(..)
+  , mkSlackTimestamp
+  , SlackMessageText(..)
+  )
+  where
+
+-- aeson
+import Data.Aeson
+
+-- base
+import Data.Monoid
+import GHC.Generics (Generic)
+
+-- errors
+import Control.Error (hush)
+
+-- http-api-data
+import Web.HttpApiData
+
+-- text
+import Data.Text (Text)
+import qualified Data.Text as T
+import Data.Text.Read (decimal)
+
+-- time
+import Data.Time.Clock
+import Data.Time.Clock.POSIX
+
+-- Ord to allow it to be a key of a Map
+newtype Color = Color { unColor :: Text }
+  deriving (Eq, Ord, Generic, Show, FromJSON)
+
+-- Ord to allow it to be a key of a Map
+newtype UserId = UserId { unUserId :: Text }
+  deriving (Eq, Ord, Generic, Show, FromJSON)
+
+-- | Message text in the format returned by Slack,
+-- see https://api.slack.com/docs/message-formatting
+-- Consider using 'messageToHtml' for displaying.
+newtype SlackMessageText = SlackMessageText { unSlackMessageText :: Text}
+  deriving (Eq, Generic, Show, FromJSON)
+
+data SlackTimestamp =
+  SlackTimestamp
+    { slackTimestampTs :: Text
+    , slackTimestampTime :: UTCTime
+    }
+  deriving (Eq, Show)
+
+instance Ord SlackTimestamp where
+    compare (SlackTimestamp _ a) (SlackTimestamp _ b) = compare a b
+
+mkSlackTimestamp :: UTCTime -> SlackTimestamp
+mkSlackTimestamp utctime = SlackTimestamp (T.pack (show @Integer unixts) <> ".000000") utctime
+  where unixts = floor $ toRational $ utcTimeToPOSIXSeconds utctime
+
+instance ToHttpApiData SlackTimestamp where
+  toQueryParam (SlackTimestamp contents _) = contents
+
+instance FromJSON SlackTimestamp where
+  parseJSON = withText "Slack ts" $ \contents ->
+    maybe (fail "Invalid slack ts")
+          (pure . SlackTimestamp contents)
+          (slackTimestampToTime contents)
+
+slackTimestampToTime :: Text -> Maybe UTCTime
+slackTimestampToTime txt =
+  posixSecondsToUTCTime . realToFrac @Integer . fst <$> hush (decimal txt)

--- a/tests/Web/Slack/MessageParserSpec.hs
+++ b/tests/Web/Slack/MessageParserSpec.hs
@@ -7,36 +7,51 @@ import Test.Hspec
 
 -- slack-web
 import Web.Slack.MessageParser
+import Web.Slack.Types
+
+-- text
+import Data.Text (Text)
+
+testGetUserDesc :: UserId -> Text
+testGetUserDesc (UserId "USER1") = "user_one"
+testGetUserDesc x = unUserId x
+
+msgToHtml :: Text -> Text
+msgToHtml = messageToHtml testGetUserDesc . SlackMessageText
 
 spec :: Spec
 spec =
   describe "message contents parsing" $ do
     it "handles the trivial case well" $
-      messageToHtml "hello" `shouldBe` "hello"
+      msgToHtml "hello" `shouldBe` "hello"
     it "converts a simple message to HTML correctly" $
-      messageToHtml "_hello_ *world* <http://www.google.com|google> `code` ```longer\ncode```"
+      msgToHtml "_hello_ *world* <http://www.google.com|google> `code` ```longer\ncode```"
         `shouldBe`
         "<i>hello</i> <b>world</b> <a href='http://www.google.com'>google</a> <code>code</code> <pre>longer\ncode</pre>"
     it "degrades properly to return the input message if it's incorrect" $
-      messageToHtml "link not closed <bad"
+      msgToHtml "link not closed <bad"
         `shouldBe`
         "link not closed <bad"
     it "creates italics sections only at word boundaries" $
-      messageToHtml "false_positive" `shouldBe` "false_positive"
+      msgToHtml "false_positive" `shouldBe` "false_positive"
     it "handles bold & italics simultaneously" $
-      messageToHtml "*_both_*" `shouldBe` "<b><i>both</i></b>"
+      msgToHtml "*_both_*" `shouldBe` "<b><i>both</i></b>"
     it "aborts nicely on interspersed bold & italics" $
-      messageToHtml "inter *sper_ *sed_" `shouldBe` "inter *sper_ *sed_"
+      msgToHtml "inter *sper_ *sed_" `shouldBe` "inter *sper_ *sed_"
     it "parses blockquotes properly" $
-      messageToHtml "look at this:\n&gt; test *wow*" `shouldBe` "look at this:\n<blockquote>test <b>wow</b></blockquote>"
+      msgToHtml "look at this:\n&gt; test *wow*" `shouldBe` "look at this:\n<blockquote>test <b>wow</b></blockquote>"
     it "parses code blocks properly" $
-      messageToHtml "look at this:\n```test *wow*```" `shouldBe` "look at this:\n<pre>test *wow*</pre>"
+      msgToHtml "look at this:\n```test *wow*```" `shouldBe` "look at this:\n<pre>test *wow*</pre>"
     it "handles non-italics underscores in text well" $
       -- need to put other HTML symbols, otherwise if the parsing fails
       -- i won't find out since we default to returning the input on
       -- parsing failure
-      messageToHtml "a:\n&gt;b.\n:slightly_smiling_face:" `shouldBe` "a:\n<blockquote>b.</blockquote>:slightly_smiling_face:"
+      msgToHtml "a:\n&gt;b.\n:slightly_smiling_face:" `shouldBe` "a:\n<blockquote>b.</blockquote>:slightly_smiling_face:"
     it "properly parses multiline blockquotes" $
-      messageToHtml "&gt; first row\n&gt; second row\nthird row\n&gt; fourth row"
+      msgToHtml "&gt; first row\n&gt; second row\nthird row\n&gt; fourth row"
         `shouldBe`
         "<blockquote>first row<br/>second row</blockquote>third row\n<blockquote>fourth row</blockquote>"
+    it "converts usernames" $
+      msgToHtml "<@USER1> should be converted, <@USER1|default> stay default"
+        `shouldBe`
+        "@user_one should be converted, @default stay default"


### PR DESCRIPTION
it turns out if you type @username in a slack chat, when we fetch back, we get <@USERID>, which is not very readable. So I now parse this ID, and in the HTML export offer the option to replace it by the username. that does mean the conversion to html can't be fully automatic anymore: you must give me the user list as provided by slack.

i also improved haddock apidocs (not only for this new feature), and made sure some types were exported that should have been exported already before. I also introduced the new non-exported module "Types" to make it easier to avoid cyclic dependencies between modules.

for now i still don't export the AST for the parsed messages, although it could give some flexibility to users, because I expect its format to still potentially change in the future.