### PR TITLE
Parsing improvements

### DIFF
--- a/src/Web/Slack/MessageParser.hs
+++ b/src/Web/Slack/MessageParser.hs
@@ -81,7 +81,7 @@ italicsEndSymbol :: SlackParser ()
 italicsEndSymbol = void $ char '_' >> lookAhead wordBoundary
 
 wordBoundary :: SlackParser ()
-wordBoundary = void (oneOf [' ', '\n', '*', '_', ',', '`', '?', '!', ':', ';']) <|> eof
+wordBoundary = void (oneOf [' ', '\n', '*', '_', ',', '`', '?', '!', ':', ';', '.']) <|> eof
 
 parseBoldSection :: SlackParser SlackMsgItem
 parseBoldSection = fmap SlackMsgItemBoldSection $

--- a/src/Web/Slack/MessageParser.hs
+++ b/src/Web/Slack/MessageParser.hs
@@ -71,7 +71,8 @@ parsePlainText = SlackMsgItemPlainText . T.pack <$>
 -- only at word boundary. for instance 'my_word'
 -- doesn't trigger an italics section.
 parseWhitespace :: Bool -> SlackParser SlackMsgItem
-parseWhitespace True = SlackMsgItemPlainText . T.pack <$> some (oneOf [' ', '\n'])
+parseWhitespace True =
+  SlackMsgItemPlainText . T.pack <$> some (oneOf [' ', '\n'])
 parseWhitespace False = SlackMsgItemPlainText . T.pack <$> some (oneOf [' '])
 
 boldEndSymbol :: SlackParser ()
@@ -143,7 +144,7 @@ messageToHtml' getUserDesc = foldr ((<>) . msgItemToHtml getUserDesc) ""
 
 msgItemToHtml :: (UserId -> Text) -> SlackMsgItem -> Text
 msgItemToHtml getUserDesc = \case
-  SlackMsgItemPlainText txt -> txt
+  SlackMsgItemPlainText txt -> T.replace "\n" "<br/>" txt
   SlackMsgItemBoldSection cts -> "<b>" <> messageToHtml' getUserDesc cts <> "</b>"
   SlackMsgItemItalicsSection cts -> "<i>" <> messageToHtml' getUserDesc cts <> "</i>"
   SlackMsgItemLink txt url -> "<a href='" <> unSlackUrl url <> "'>" <> txt <> "</a>"

--- a/tests/Web/Slack/MessageParserSpec.hs
+++ b/tests/Web/Slack/MessageParserSpec.hs
@@ -39,21 +39,23 @@ spec =
     it "aborts nicely on interspersed bold & italics" $
       msgToHtml "inter *sper_ *sed_" `shouldBe` "inter *sper_ *sed_"
     it "parses blockquotes properly" $
-      msgToHtml "look at this:\n&gt; test *wow*" `shouldBe` "look at this:\n<blockquote>test <b>wow</b></blockquote>"
+      msgToHtml "look at this:\n&gt; test *wow*" `shouldBe` "look at this:<br/><blockquote>test <b>wow</b></blockquote>"
     it "parses code blocks properly" $
-      msgToHtml "look at this:\n```test *wow*```" `shouldBe` "look at this:\n<pre>test *wow*</pre>"
+      msgToHtml "look at this:\n```test *wow*```" `shouldBe` "look at this:<br/><pre>test *wow*</pre>"
     it "handles non-italics underscores in text well" $
       -- need to put other HTML symbols, otherwise if the parsing fails
       -- i won't find out since we default to returning the input on
       -- parsing failure
-      msgToHtml "a:\n&gt;b.\n:slightly_smiling_face:" `shouldBe` "a:\n<blockquote>b.</blockquote>:slightly_smiling_face:"
+      msgToHtml "a:\n&gt;b.\n:slightly_smiling_face:" `shouldBe` "a:<br/><blockquote>b.</blockquote>:slightly_smiling_face:"
     it "properly parses multiline blockquotes" $
       msgToHtml "&gt; first row\n&gt; second row\nthird row\n&gt; fourth row"
         `shouldBe`
-        "<blockquote>first row<br/>second row</blockquote>third row\n<blockquote>fourth row</blockquote>"
+        "<blockquote>first row<br/>second row</blockquote>third row<br/><blockquote>fourth row</blockquote>"
     it "converts usernames" $
       msgToHtml "<@USER1> should be converted, <@USER1|default> stay default"
         `shouldBe`
         "@user_one should be converted, @default stay default"
+    it "converts carriage returns" $
+      msgToHtml "a\nb" `shouldBe` "a<br/>b"
     it "handles full stops as punctuation" $
       msgToHtml "*b*." `shouldBe` "<b>b</b>."

--- a/tests/Web/Slack/MessageParserSpec.hs
+++ b/tests/Web/Slack/MessageParserSpec.hs
@@ -2,6 +2,9 @@
 
 module Web.Slack.MessageParserSpec (spec) where
 
+-- base
+import Data.Monoid
+
 -- hspec
 import Test.Hspec
 
@@ -16,8 +19,13 @@ testGetUserDesc :: UserId -> Text
 testGetUserDesc (UserId "USER1") = "user_one"
 testGetUserDesc x = unUserId x
 
+testHtmlRenderers :: HtmlRenderers
+testHtmlRenderers = HtmlRenderers
+  { emoticonRenderer = \x -> ":>" <> x <> "<:"
+  }
+
 msgToHtml :: Text -> Text
-msgToHtml = messageToHtml testGetUserDesc . SlackMessageText
+msgToHtml = messageToHtml testHtmlRenderers testGetUserDesc . SlackMessageText
 
 spec :: Spec
 spec =
@@ -46,7 +54,7 @@ spec =
       -- need to put other HTML symbols, otherwise if the parsing fails
       -- i won't find out since we default to returning the input on
       -- parsing failure
-      msgToHtml "a:\n&gt;b.\n:slightly_smiling_face:" `shouldBe` "a:<br/><blockquote>b.</blockquote>:slightly_smiling_face:"
+      msgToHtml "a:\n&gt;b.\n:slightly_smiling_face:" `shouldBe` "a:<br/><blockquote>b.</blockquote>:>slightly_smiling_face<:"
     it "properly parses multiline blockquotes" $
       msgToHtml "&gt; first row\n&gt; second row\nthird row\n&gt; fourth row"
         `shouldBe`

--- a/tests/Web/Slack/MessageParserSpec.hs
+++ b/tests/Web/Slack/MessageParserSpec.hs
@@ -55,3 +55,5 @@ spec =
       msgToHtml "<@USER1> should be converted, <@USER1|default> stay default"
         `shouldBe`
         "@user_one should be converted, @default stay default"
+    it "handles full stops as punctuation" $
+      msgToHtml "*b*." `shouldBe` "<b>b</b>."


### PR DESCRIPTION
three commits (I intend to rebase not squash, as they're independent from one another).

* parse "." as punctuation ('*bold*.' was not recognized as bold)
* transform \n in < br/ > in the html
* parse slack emoticons and let the user provide a custom renderer. In my app, i'm using https://github.com/iamcal/emoji-data to render them in a nicer way (I did not include that bit in slack-web, just giving the user the possibility to implement something like that on their own if they want)