### PR TITLE
relax dependencies, use newer stackage snapshot

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,10 +4,13 @@ dependencies:
     - ~/.stack/
     - .stack-work/
 
+  pre:
+    - stack upgrade
+
   override:
     - stack setup
     - stack build --only-dependencies
-    - stack build --only-dependencies --resolver lts-8.3
+    - stack build --only-dependencies --resolver lts-8.3 --install-ghc
 
 test:
 

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -44,14 +44,14 @@ library
       Web.Slack.Types
       Web.Slack.Util
   build-depends:
-      aeson >= 1.0 && < 1.2
-    , base >= 4.9 && < 4.10
+      aeson >= 1.0 && < 1.3
+    , base >= 4.9 && < 4.11
     , containers
     , http-api-data >= 0.3 && < 0.4
     , http-client >= 0.5 && < 0.6
     , http-client-tls >= 0.3 && < 0.4
-    , servant >= 0.9 && < 0.11
-    , servant-client >= 0.9 && < 0.11
+    , servant >= 0.9 && < 0.12
+    , servant-client >= 0.9 && < 0.12
     , text >= 1.2 && < 1.3
     , transformers
     , mtl
@@ -78,7 +78,7 @@ test-suite tests
       Web.Slack.MessageParserSpec
       Web.Slack.Types
   build-depends:
-      base >= 4.9 && < 4.10
+      base >= 4.9 && < 4.11
     , containers
     , aeson
     , errors

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: nightly-2017-02-26
+resolver: nightly-2017-08-12


### PR DESCRIPTION
relax dependencies, use newer stackage snapshot.

i would also be interested to maintain slack-web on stackage, if you don't have the time. i already have two packages on hackage, so I could also upload it hackage, which would be needed to be able to maintain it on stackage. the question, is do you think it's a good idea?