### PR TITLE
support for megaparsec6

### DIFF
--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -1,5 +1,5 @@
 name: slack-web
-version: 0.2.0
+version: 0.2.0.1
 
 build-type: Simple
 cabal-version: >= 1.21

--- a/src/Web/Slack/MessageParser.hs
+++ b/src/Web/Slack/MessageParser.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE CPP #-}
 
 -- | See https://api.slack.com/docs/message-formatting
 --
@@ -16,9 +17,11 @@ import Control.Monad
 import Data.List
 import Data.Maybe
 import Data.Monoid
+import Data.Void
 
 -- megaparsec
 import Text.Megaparsec
+import Text.Megaparsec.Char
 
 -- mtl
 import Data.Functor.Identity
@@ -46,7 +49,13 @@ data SlackMsgItem
   | SlackMsgItemEmoticon Text
   deriving (Show, Eq)
 
-type SlackParser a = ParsecT Dec T.Text Identity a
+#if MIN_VERSION_megaparsec(6,0,0)
+type MegaparsecError = Void
+#else
+type MegaparsecError = Dec
+#endif
+
+type SlackParser a = ParsecT MegaparsecError T.Text Identity a
 
 parseMessage :: Text -> [SlackMsgItem]
 parseMessage input = fromMaybe [SlackMsgItemPlainText input] $


### PR DESCRIPTION
so the hackage build failed because it built slack-web against megaparsec6:
https://hackage.haskell.org/package/slack-web-0.2.0/reports/2

and of course hackage is correct, I didn't put any constraint on the megaparsec dependency (intending to rely on stackage). Now stackage is in the process of moving to megaparsec6 anyway (but did not achieve it yet):
https://github.com/fpco/stackage/issues/2666

so the best is probably to support both for the time being, although that means some ugly CPP :-(

also changed the version to 0.2.0.1, intend to deploy it to hackage when this gets to master.