### PR TITLE
first draft at servant-0.12 support

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,12 +9,10 @@ dependencies:
 
   override:
     - stack setup
-    - stack build --only-dependencies
-    - stack build --only-dependencies --resolver lts-8.3 --install-ghc
+    - stack build --only-dependencies --install-ghc
 
 test:
 
   override:
     - stack build
-    - stack build --resolver lts-8.3
     - stack test

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -50,8 +50,8 @@ library
     , http-api-data >= 0.3 && < 0.4
     , http-client >= 0.5 && < 0.6
     , http-client-tls >= 0.3 && < 0.4
-    , servant >= 0.9 && < 0.13
-    , servant-client >= 0.9 && < 0.13
+    , servant >= 0.12 && < 0.13
+    , servant-client >= 0.12 && < 0.13
     , servant-client-core >= 0.12 && < 0.13
     , text >= 1.2 && < 1.3
     , transformers

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -50,8 +50,9 @@ library
     , http-api-data >= 0.3 && < 0.4
     , http-client >= 0.5 && < 0.6
     , http-client-tls >= 0.3 && < 0.4
-    , servant >= 0.9 && < 0.12
-    , servant-client >= 0.9 && < 0.12
+    , servant >= 0.9 && < 0.13
+    , servant-client >= 0.9 && < 0.13
+    , servant-client-core >= 0.12 && < 0.13
     , text >= 1.2 && < 1.3
     , transformers
     , mtl

--- a/src/Web/Slack.hs
+++ b/src/Web/Slack.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -65,14 +64,9 @@ import Control.Monad.Reader
 import Servant.API
 
 -- servant-client
-import Servant.Client (ClientM, BaseUrl(..), Scheme(..), ClientEnv(ClientEnv), runClientM, client)
-#if MIN_VERSION_servant_client(0,12,0)
+import Servant.Client hiding (Response, baseUrl)
 import Servant.Client.Core (Request, appendToQueryString, ServantError)
 import Servant.Client.Core.Internal.Auth
-#else
-import Servant.Common.Req (Req, appendToQueryString)
-type Request = Req
-#endif
 
 -- slack-web
 import qualified Web.Slack.Api as Api

--- a/src/Web/Slack/Common.hs
+++ b/src/Web/Slack/Common.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -40,13 +39,9 @@ import GHC.Generics (Generic)
 -- http-api-data
 import Web.HttpApiData
 import Web.FormUrlEncoded
-  
+
 -- servant-client
-#if MIN_VERSION_servant_client(0,12,0)
 import Servant.Client
-#else
-import Servant.Common.Req
-#endif
 
 -- slack-web
 import Web.Slack.Types

--- a/src/Web/Slack/Common.hs
+++ b/src/Web/Slack/Common.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -41,7 +42,11 @@ import Web.HttpApiData
 import Web.FormUrlEncoded
   
 -- servant-client
+#if MIN_VERSION_servant_client(0,12,0)
+import Servant.Client
+#else
 import Servant.Common.Req
+#endif
 
 -- slack-web
 import Web.Slack.Types

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,5 @@
 resolver: nightly-2017-08-12
+extra-deps:
+- servant-0.12
+- servant-client-0.12
+- servant-client-core-0.12


### PR DESCRIPTION
so stackage want to migrate to servant-0.12 and we must port slack-web.
This is a first stab at it, everything seems to work, _but_ as I wrote [there](https://github.com/fpco/stackage/issues/3013), I don't know how to make slack-web build against both servant-0.11 and servant-0.12 without introducing at least a cabal flag.

In the meantime if you want you can peek at the changes. Note that I half-did it. This patch half supports servant-0.11 and half doesn't ;-) I stopped with the #ifdefs when I hit the .cabal dependency issue. Either I'll drop completely 0.11 or do something else depending on what the stackage people suggest (hopefully they'll answer).