### PR TITLE
support for servant 0.13 (see stackage #3281)

### DIFF
--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -50,9 +50,9 @@ library
     , http-api-data >= 0.3 && < 0.4
     , http-client >= 0.5 && < 0.6
     , http-client-tls >= 0.3 && < 0.4
-    , servant >= 0.12 && < 0.13
-    , servant-client >= 0.12 && < 0.13
-    , servant-client-core >= 0.12 && < 0.13
+    , servant >= 0.12 && < 0.14
+    , servant-client >= 0.12 && < 0.14
+    , servant-client-core >= 0.12 && < 0.14
     , text >= 1.2 && < 1.3
     , transformers
     , mtl

--- a/src/Web/Slack.hs
+++ b/src/Web/Slack.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE CPP #-}
 
 ----------------------------------------------------------------------
 -- |
@@ -80,6 +81,11 @@ import qualified Web.Slack.User as User
 
 -- text
 import Data.Text (Text)
+
+#if !MIN_VERSION_servant(0,13,0)
+mkClientEnv :: Manager -> BaseUrl -> ClientEnv
+mkClientEnv = ClientEnv
+#endif
 
 class HasManager a where
     getManager :: a -> Manager
@@ -543,7 +549,7 @@ run
 run clientAction = do
   env <- ask
   let baseUrl = BaseUrl Https "slack.com" 443 "/api"
-  unnestErrors <$> liftIO (runClientM clientAction $ ClientEnv (getManager env) baseUrl)
+  unnestErrors <$> liftIO (runClientM clientAction $ mkClientEnv (getManager env) baseUrl)
 
 mkSlackAuthenticateReq :: (MonadReader env m, HasToken env)
   => m (AuthenticatedRequest (AuthProtect "token"))

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,6 @@
-resolver: nightly-2017-08-12
+resolver: nightly-2018-02-09
 extra-deps:
-- servant-0.12
-- servant-client-0.12
-- servant-client-core-0.12
+- servant-0.13
+- servant-client-0.13
+- servant-client-core-0.13
+- http-types-0.12.1


### PR DESCRIPTION
support servant 0.13. I tested it pretty lightly (note our tests don't make any slack requests), but it's looking good. Had to use some CPP though.
Needed for stackage.
I'll release shortly after this is merged so stackage can increase the servant version.