### PR TITLE
fixes #53 make SlackClientError an instance of Exception and Typeable.

### DIFF
--- a/src/Web/Slack/Common.hs
+++ b/src/Web/Slack/Common.hs
@@ -34,6 +34,8 @@ import Data.Aeson
 import Data.Aeson.TH
 
 -- base
+import Control.Exception
+import Data.Typeable
 import GHC.Generics (Generic)
 
 -- http-api-data
@@ -140,4 +142,6 @@ data SlackClientError
     -- ^ errors from the network connection
     | SlackError Text
     -- ^ errors returned by the slack API
-  deriving (Eq, Generic, Show)
+  deriving (Eq, Generic, Show, Typeable)
+
+instance Exception SlackClientError


### PR DESCRIPTION
if there are no comments, tomorrow i'll merge this to master and release a new version of slack-web (I've already merged servant-0.13 support to master).