### PR TITLE
relax base & aeson dependencies and release 0.2.0.4

### DIFF
--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -1,5 +1,5 @@
 name: slack-web
-version: 0.2.0.3
+version: 0.2.0.4
 
 build-type: Simple
 cabal-version: >= 1.21
@@ -44,8 +44,8 @@ library
       Web.Slack.Types
       Web.Slack.Util
   build-depends:
-      aeson >= 1.0 && < 1.3
-    , base >= 4.9 && < 4.11
+      aeson >= 1.0 && < 1.4
+    , base >= 4.9 && < 4.12
     , containers
     , http-api-data >= 0.3 && < 0.4
     , http-client >= 0.5 && < 0.6
@@ -79,7 +79,7 @@ test-suite tests
       Web.Slack.MessageParserSpec
       Web.Slack.Types
   build-depends:
-      base >= 4.9 && < 4.11
+      base >= 4.9 && < 4.12
     , containers
     , aeson
     , errors


### PR DESCRIPTION
fixes #59 

I was waiting on a new release of servant, but now the servant hackage page says it allows aeson 1.3 although its git code says it doesn't. It's a bit strange.
I've also relaxed the base dependency. Since I forced the versions in the stack.yaml and everything builds and the tests pass, it should be fine. I didn't actually test any request to slack though.

 If you agree to this change, I'll then release 0.2.0.4 to hackage.

Notice that in this build config that I'm pushing we get that warning, but I'm not really worried, it'll be fine on stack, and the stack.yaml doesn't go on hackage anyway:

```
Warning:         
    This package indirectly depends on multiple versions of the same package. This is very likely to cause a compile failure.
      package deepseq (deepseq-1.4.3.0) requires array-0.5.2.0
      package text (text-1.2.3.0-KRWCvegDwmZ4sIlKAPiVbO) requires array-0.5.2.0-3rwfBkQnpydET16BGB2TZY
      package streaming-commons (streaming-commons-0.2.0.0-1f5t8i6Hiw6D7aYAXWHawN) requires array-0.5.2.0-3rwfBkQnpydET16BGB2TZY
      package stm (stm-2.4.5.0-LqtWz3ubfN5K1lAXrGDgE9) requires array-0.5.2.0-3rwfBkQnpydET16BGB2TZY
      package integer-logarithms (integer-logarithms-1.0.2.1-L2zevSXWvCRAi2fWmSed6J) requires array-0.5.2.0-3rwfBkQnpydET16BGB2TZY
      package http-types (http-types-0.12.1-32lPx9WrgH9FCfmMsW6J0X) requires array-0.5.2.0-3rwfBkQnpydET16BGB2TZY
      package http-client (http-client-0.5.11-2BM1a2Y3lHACwxxGQcXWZB) requires array-0.5.2.0-3rwfBkQnpydET16BGB2TZY
      package hspec-core (hspec-core-2.5.0-Lbs9m2pICMf3QoSd3hzAa1) requires array-0.5.2.0-3rwfBkQnpydET16BGB2TZY
      package deepseq (deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd) requires array-0.5.2.0-3rwfBkQnpydET16BGB2TZY
      package containers (containers-0.5.11.0-HbbyVrBvQD11U9YDVV2w4E) requires array-0.5.2.0-3rwfBkQnpydET16BGB2TZY
      package cereal (cereal-0.5.5.0-GHDbrwczmJ1FOAAwmnAEzI) requires array-0.5.2.0-3rwfBkQnpydET16BGB2TZY
      package binary (binary-0.8.5.1-8lGiPWS1H4jEnAvkZuW1ML) requires array-0.5.2.0-3rwfBkQnpydET16BGB2TZY
      package attoparsec (attoparsec-0.13.2.2-HZzCRQoiF0c7zfcpJppuWE) requires array-0.5.2.0-3rwfBkQnpydET16BGB2TZY
      package pretty (pretty-1.1.3.6) requires deepseq-1.4.3.0
      package vector (vector-0.12.0.1-1m5wlD0ZFNtwfJjslaQYX) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package uuid-types (uuid-types-1.0.3-2DiagiU6VQ9E9WwXGOGIom) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package unordered-containers (unordered-containers-0.2.9.0-5mX9fI59QyLebQ9qBIm45) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package time (time-1.8.0.2-K3anBzJwqTl8Kcrr62Myrd) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package text (text-1.2.3.0-KRWCvegDwmZ4sIlKAPiVbO) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package tagged (tagged-0.8.5-E9byxRryEC6JFXufOziMxB) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package scientific (scientific-0.3.5.3-7UtCRdNFprHCYWy0Ncsq0s) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package process (process-1.6.3.0-I92H1ZBkrNDEbXFfQkGlek) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package network-uri (network-uri-2.6.1.0-EdKizl0mUi2AivLwtBgSFq) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package memory (memory-0.14.16-Ku6joHYJb6d8lBQWyoOD1D) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package megaparsec (megaparsec-6.4.1-EKD6CXy9rkOFubDXzCSKxh) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package http-client (http-client-0.5.11-2BM1a2Y3lHACwxxGQcXWZB) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package hspec-core (hspec-core-2.5.0-Lbs9m2pICMf3QoSd3hzAa1) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package hourglass (hourglass-0.2.11-IIqzuf0Su4EH83aBmsIIGM) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package hashable (hashable-1.2.7.0-CWKjtQAJzI0HVNVkDX9m0s) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package generics-sop (generics-sop-0.3.2.0-DJ9jaFaVjirD2dU9MYJOV8) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package dlist (dlist-0.8.0.4-IQ1XETvDsKgF4lRwvOPESM) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package cryptonite (cryptonite-0.25-3YiuxSbOzO7Q7p7eLtYXn) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package cookie (cookie-0.4.4-98KNlGGcRb1bTJPF9LUrh) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package containers (containers-0.5.11.0-HbbyVrBvQD11U9YDVV2w4E) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package case-insensitive (case-insensitive-1.2.0.11-1G4mi7THWpLLPqffswISNy) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package bytestring (bytestring-0.10.8.2-AGrKlZJS40L1iM6KYeTAQB) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package blaze-builder (blaze-builder-0.4.1.0-LXGSBxrW4EXGbI2d80AxMJ) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package attoparsec (attoparsec-0.13.2.2-HZzCRQoiF0c7zfcpJppuWE) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package aeson (aeson-1.3.0.0-CadJQ4yn54pEy1mq83QHuc) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package QuickCheck (QuickCheck-2.11.3-4YkDIUfIEwiGtcHOhC8KWT) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd
      package HUnit (HUnit-1.6.0.0-3HXEjzMSWJs4yQjvB0bmuW) requires deepseq-1.4.3.0-KWL8DTHEdyA7Lma8sSflEd

```