### PR TITLE
allow aeson-1.4, release 0.2.0.5

### DIFF
--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -1,5 +1,5 @@
 name: slack-web
-version: 0.2.0.4
+version: 0.2.0.5
 
 build-type: Simple
 cabal-version: >= 1.21
@@ -44,7 +44,7 @@ library
       Web.Slack.Types
       Web.Slack.Util
   build-depends:
-      aeson >= 1.0 && < 1.4
+      aeson >= 1.0 && < 1.5
     , base >= 4.9 && < 4.12
     , containers
     , http-api-data >= 0.3 && < 0.4


### PR DESCRIPTION
stack have [a bug to introduce aeson-1.4](https://github.com/commercialhaskell/stackage/issues/3728), but we prevent it in our bounds.
i tried building against 1.4.0.0 and we build and the tests pass (that said the tests don't test aeson, but if it builds..).

to be clear I tested with `stack test` when adding also:

```
+
+extra-deps:
+- aeson-1.4.0.0
```

in the stack.yaml, but I'm not committing that. If you agree to merge, I'll then tag & release 0.2.0.5 on hackage.