### PR TITLE
allow servant-0.14, release 0.2.0.6

### DIFF
--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -1,5 +1,5 @@
 name: slack-web
-version: 0.2.0.5
+version: 0.2.0.6
 
 build-type: Simple
 cabal-version: >= 1.21
@@ -50,9 +50,9 @@ library
     , http-api-data >= 0.3 && < 0.4
     , http-client >= 0.5 && < 0.6
     , http-client-tls >= 0.3 && < 0.4
-    , servant >= 0.12 && < 0.14
-    , servant-client >= 0.12 && < 0.14
-    , servant-client-core >= 0.12 && < 0.14
+    , servant >= 0.12 && < 0.15
+    , servant-client >= 0.12 && < 0.15
+    , servant-client-core >= 0.12 && < 0.15
     , text >= 1.2 && < 1.3
     , transformers
     , mtl


### PR DESCRIPTION
fixes https://github.com/commercialhaskell/stackage/issues/3750

I only tested it compiles & tests pass. To test the new servant version, I locally had in my stack.yaml =>
```

resolver: lts-11.11
extra-deps:
- aeson-1.4.0.0
- servant-0.14
- servant-client-0.14
- servant-client-core-0.14
- base-compat-0.10.1
- exceptions-0.10.0
- http-api-data-0.3.8.1
- transformers-0.5.5.0
- transformers-base-0.4.5.2
- transformers-compat-0.6.2
- vault-0.3.1.1
allow-newer: true

```