### PR TITLE
use new cabal version format

### DIFF
--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -2,7 +2,7 @@ name: slack-web
 version: 0.2.0.6
 
 build-type: Simple
-cabal-version: >= 1.21
+cabal-version: 1.21
 
 license: MIT
 license-file: LICENSE.md


### PR DESCRIPTION
got warning upon publishing to hackage:

    Packages relying on Cabal 1.12 or later should specify a version range of the form 'cabal-version: x.y'. Use 'cabal-version: 1.21'.

0.2.0.6 is on hackage anyway so that's just for the future. the other thing is that i didn't manage to create a tag for the release, github says:

    Tag could not be created. Pre-receive hooks failed. 

I won't be able to deal with the tag for now. It's not really a big deal anyway (edit: managed to make the tag now, i guess it was a temporary glitch).