### PR TITLE
relax 'base' dependency, release 0.2.0.7

### DIFF
--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -1,5 +1,5 @@
 name: slack-web
-version: 0.2.0.6
+version: 0.2.0.7
 
 build-type: Simple
 cabal-version: 1.21
@@ -45,7 +45,7 @@ library
       Web.Slack.Util
   build-depends:
       aeson >= 1.0 && < 1.5
-    , base >= 4.9 && < 4.12
+    , base >= 4.9 && < 4.13
     , containers
     , http-api-data >= 0.3 && < 0.4
     , http-client >= 0.5 && < 0.6
@@ -79,7 +79,7 @@ test-suite tests
       Web.Slack.MessageParserSpec
       Web.Slack.Types
   build-depends:
-      base >= 4.9 && < 4.12
+      base >= 4.9 && < 4.13
     , containers
     , aeson
     , errors


### PR DESCRIPTION
need to relax the base dependency for ghc 8.6. tested with stackage nightly, builds fine and the tests go through.