### PR TITLE
Megarparsec fixes, remove redundant imports, release, update nightly version date

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build-lts:
     docker:
-      - image: fpco/stack-build:lts-11.11
+      - image: fpco/stack-build:lts-12.16
     steps:
       - checkout
       - restore_cache:
@@ -20,7 +20,7 @@ jobs:
 
   build-nightly:
     docker:
-      - image: fpco/stack-build:lts-11.11
+      - image: fpco/stack-build:lts-12.16
     steps:
       - checkout
       - restore_cache:

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -58,7 +58,7 @@ library
     , mtl
     , time
     , errors
-    , megaparsec
+    , megaparsec >= 5.0 && < 7.1
   default-language:
       Haskell2010
   ghc-options:
@@ -87,7 +87,7 @@ test-suite tests
     , http-api-data
     , text
     , time
-    , megaparsec
+    , megaparsec >= 5.0 && < 7.1
   default-language:
     Haskell2010
   ghc-options:

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -1,5 +1,5 @@
 name: slack-web
-version: 0.2.0.7
+version: 0.2.0.8
 
 build-type: Simple
 cabal-version: 1.21

--- a/src/Web/Slack/MessageParser.hs
+++ b/src/Web/Slack/MessageParser.hs
@@ -16,7 +16,6 @@ module Web.Slack.MessageParser
 import Control.Monad
 import Data.List
 import Data.Maybe
-import Data.Monoid
 import Data.Void
 
 -- megaparsec

--- a/src/Web/Slack/MessageParser.hs
+++ b/src/Web/Slack/MessageParser.hs
@@ -55,6 +55,11 @@ type MegaparsecError = Void
 type MegaparsecError = Dec
 #endif
 
+#if MIN_VERSION_megaparsec(7,0,0)
+#else
+anySingle = anyChar
+#endif
+
 type SlackParser a = ParsecT MegaparsecError T.Text Identity a
 
 parseMessage :: Text -> [SlackMsgItem]
@@ -138,7 +143,7 @@ parseLink = do
 
 parseCode :: SlackParser SlackMsgItem
 parseCode = SlackMsgItemCodeSection . T.pack <$>
-  (string "```" >> manyTill anyChar (string "```"))
+  (string "```" >> manyTill anySingle (string "```"))
 
 parseInlineCode :: SlackParser SlackMsgItem
 parseInlineCode = SlackMsgItemInlineCodeSection . T.pack <$>

--- a/src/Web/Slack/Types.hs
+++ b/src/Web/Slack/Types.hs
@@ -25,7 +25,6 @@ module Web.Slack.Types
 import Data.Aeson
 
 -- base
-import Data.Monoid
 import GHC.Generics (Generic)
 
 -- errors

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,1 +1,1 @@
-resolver: nightly-2018-05-29
+resolver: nightly-2018-11-05

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.11
+resolver: lts-12.16

--- a/tests/Web/Slack/MessageParserSpec.hs
+++ b/tests/Web/Slack/MessageParserSpec.hs
@@ -2,9 +2,6 @@
 
 module Web.Slack.MessageParserSpec (spec) where
 
--- base
-import Data.Monoid
-
 -- hspec
 import Test.Hspec
 


### PR DESCRIPTION
fixes #67 

* update circleci base docker image
* megaparsec: explicit version constraints, support megaparsec7
* update nightly version date to the latest nightly
* remove now redundant import: Data.Monoid
* release 0.2.0.8