### PR TITLE
increase 'base' dependency

### DIFF
--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -45,7 +45,7 @@ library
       Web.Slack.Util
   build-depends:
       aeson >= 1.0 && < 1.5
-    , base >= 4.9 && < 4.13
+    , base >= 4.11 && < 4.13
     , containers
     , http-api-data >= 0.3 && < 0.4
     , http-client >= 0.5 && < 0.6
@@ -79,7 +79,7 @@ test-suite tests
       Web.Slack.MessageParserSpec
       Web.Slack.Types
   build-depends:
-      base >= 4.9 && < 4.13
+      base >= 4.11 && < 4.13
     , containers
     , aeson
     , errors


### PR DESCRIPTION
i tried setting up a circleci test on base-4.9 if we want to support it -- I didn't make it. We could add back the import to Data.Monoid but the simplest is probably to drop these versions.