### PR TITLE
Servant 015 plus release

### DIFF
--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -47,12 +47,12 @@ library
       aeson >= 1.0 && < 1.5
     , base >= 4.9 && < 4.13
     , containers
-    , http-api-data >= 0.3 && < 0.4
+    , http-api-data >= 0.3 && < 0.5
     , http-client >= 0.5 && < 0.6
     , http-client-tls >= 0.3 && < 0.4
-    , servant >= 0.12 && < 0.15
-    , servant-client >= 0.12 && < 0.15
-    , servant-client-core >= 0.12 && < 0.15
+    , servant >= 0.12 && < 0.16
+    , servant-client >= 0.12 && < 0.16
+    , servant-client-core >= 0.12 && < 0.16
     , text >= 1.2 && < 1.3
     , transformers
     , mtl

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -1,5 +1,5 @@
 name: slack-web
-version: 0.2.0.8
+version: 0.2.0.9
 
 build-type: Simple
 cabal-version: 1.21


### PR DESCRIPTION
relax the servant-dependency, needed for https://github.com/commercialhaskell/stackage/issues/4131 and https://github.com/commercialhaskell/stackage/issues/4130.

I tested with this stack.yaml & confirmed we build & tests pass:

```
resolver: nightly-2018-11-14
extra-deps:
- http-api-data-0.4
- servant-0.15
- servant-client-0.15
- servant-client-core-0.15
- QuickCheck-2.12.6.1
- generics-sop-0.4.0.1
- hspec-core-2.6.0
- hspec-2.6.0
- hspec-discover-2.6.0
```
