### PR TITLE
Fix cabal version, add type signature

### DIFF
--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -2,7 +2,7 @@ name: slack-web
 version: 0.2.0.10
 
 build-type: Simple
-cabal-version: 1.21
+cabal-version: 1.20
 
 license: MIT
 license-file: LICENSE.md

--- a/src/Web/Slack/MessageParser.hs
+++ b/src/Web/Slack/MessageParser.hs
@@ -56,6 +56,7 @@ type MegaparsecError = Dec
 
 #if MIN_VERSION_megaparsec(7,0,0)
 #else
+anySingle :: ParsecT MegaparsecError Text Identity (Token Text)
 anySingle = anyChar
 #endif
 


### PR DESCRIPTION
I tried to release 0.2.0.10 on hackage, but it rejects the package because cabal-version 1.21 is no longer valid (was OK for the last few releases though).

I get =>

>  #Invalid package
>
>'cabal-version' refers to an unreleased/unknown cabal specification version 1.21; for a list of valid specification versions please consult https://www.haskell.org/cabal/users-guide/file-format-changelog.html

On that page it's visible that 1.20 and 1.22 are valid. According to the changelog, it seems that 1.20 is good enough for us, and probably the less risky option. Note that we used to have `>= 1.21` but I changed it to `: 1.21` due to another recent cabal format change.

In another commit, I add top-level type signature to get rid of a warning.