### PR TITLE
support servant-0.16, release 0.2.0.11

### DIFF
--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -1,5 +1,5 @@
 name: slack-web
-version: 0.2.0.10
+version: 0.2.0.11
 
 build-type: Simple
 cabal-version: 1.20
@@ -50,9 +50,9 @@ library
     , http-api-data >= 0.3 && < 0.5
     , http-client >= 0.5 && < 0.7
     , http-client-tls >= 0.3 && < 0.4
-    , servant >= 0.12 && < 0.16
-    , servant-client >= 0.12 && < 0.16
-    , servant-client-core >= 0.12 && < 0.16
+    , servant >= 0.12 && < 0.17
+    , servant-client >= 0.12 && < 0.17
+    , servant-client-core >= 0.12 && < 0.17
     , text >= 1.2 && < 1.3
     , transformers
     , mtl

--- a/src/Web/Slack/Common.hs
+++ b/src/Web/Slack/Common.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE CPP #-}
 
 ----------------------------------------------------------------------
 -- |
@@ -52,6 +53,9 @@ import Web.Slack.Util
 -- text
 import Data.Text (Text)
 
+#if !MIN_VERSION_servant(0,16,0)
+type ClientError = ServantError
+#endif
 
 -- |
 --
@@ -138,7 +142,7 @@ $(deriveFromJSON (jsonOpts "historyRsp") ''HistoryRsp)
 -- |
 -- Errors that can be triggered by a slack request.
 data SlackClientError
-    = ServantError ServantError
+    = ServantError ClientError
     -- ^ errors from the network connection
     | SlackError Text
     -- ^ errors returned by the slack API


### PR DESCRIPTION
fixes https://github.com/commercialhaskell/stackage/issues/4396

had to use some CPP to support both old and new versions.