### PR TITLE
Bump bounds, move to newer stack LTS

### DIFF
--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -1,5 +1,5 @@
 name: slack-web
-version: 0.2.0.11
+version: 0.2.0.12
 
 build-type: Simple
 cabal-version: 1.20
@@ -45,7 +45,7 @@ library
       Web.Slack.Util
   build-depends:
       aeson >= 1.0 && < 1.5
-    , base >= 4.11 && < 4.13
+    , base >= 4.11 && < 4.14
     , containers
     , http-api-data >= 0.3 && < 0.5
     , http-client >= 0.5 && < 0.7
@@ -58,7 +58,7 @@ library
     , mtl
     , time
     , errors
-    , megaparsec >= 5.0 && < 7.1
+    , megaparsec >= 5.0 && < 9
   default-language:
       Haskell2010
   ghc-options:
@@ -79,7 +79,7 @@ test-suite tests
       Web.Slack.MessageParserSpec
       Web.Slack.Types
   build-depends:
-      base >= 4.11 && < 4.13
+      base >= 4.11 && < 4.14
     , containers
     , aeson
     , errors
@@ -87,7 +87,7 @@ test-suite tests
     , http-api-data
     , text
     , time
-    , megaparsec >= 5.0 && < 7.1
+    , megaparsec >= 5.0 && < 9
   default-language:
     Haskell2010
   ghc-options:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-12.16
+resolver: lts-15.6


### PR DESCRIPTION
This bumps some bounds so that this package will build with the latest LTS snapshot.

I also bumped the resolver in the `stack.yaml` to match this.

The tests pass for me with this commit, so it doesn't seem to break anything.

