### PR TITLE
Use Authorization header for auth

### DIFF
--- a/src/Web/Slack.hs
+++ b/src/Web/Slack.hs
@@ -56,11 +56,11 @@ import Network.HTTP.Client.TLS (tlsManagerSettings)
 import Control.Monad.Reader
 
 -- servant
-import Servant.API
+import Servant.API hiding (addHeader)
 
 -- servant-client
 import Servant.Client hiding (Response, baseUrl)
-import Servant.Client.Core (Request, appendToQueryString)
+import Servant.Client.Core (Request, addHeader)
 
 -- slack-web
 import qualified Web.Slack.Api as Api
@@ -399,7 +399,7 @@ authenticateReq
   -> Request
   -> Request
 authenticateReq token =
-  appendToQueryString "token" (Just token)
+  addHeader "Authorization" $ "Bearer " <> token
 
 
 -- |


### PR DESCRIPTION
Slack recently deprecated the use of tokens in query string parameters: https://api.slack.com/changelog/2020-11-no-more-tokens-in-querystrings-for-newly-created-apps

Apps that already had a token before this update should still work with query params, but new apps won't. This PR updates `authenticateReq` so that it adds an `Authorization` header, which should work for both old and new apps. 