### PR TITLE
Add a bunch of warnings flags, expose an Internal module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .stack-work/
 dist-newstyle/
+cabal.project.local

--- a/cabal.project.local
+++ b/cabal.project.local
@@ -1,1 +1,0 @@
-packages: . ../string-variants

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
           };
 
           # for debugging
-          # inherit pkgs;
+          inherit pkgs;
 
           devShells.default =
             let haskellPackages = pkgs.haskell.packages.${ghcVer};
@@ -73,6 +73,12 @@
           let hlib = prev.haskell.lib; in
           {
             slack-web = hprev.callCabal2nix "slack-web" ./. { };
+            # test-suite doesn't compile; probably fixed in a newer nixpkgs,
+            # but there's other jackage on newer nixpkgs such as the ghcid bug:
+            # https://github.com/NixOS/nixpkgs/issues/140774#issuecomment-1186546139
+            # and the fourmolu/ormolu bug:
+            # https://github.com/tweag/ormolu/issues/927
+            mutable-containers = hlib.dontCheck hprev.mutable-containers;
           });
       };
     };

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -25,8 +25,74 @@ extra-source-files:
   CHANGELOG.md
   README.md
 
+common build-opts
+  ghc-options:
+    -Weverything
+    -- missing-exported-signatures turns off the more strict -Wmissing-signatures. See https://ghc.haskell.org/trac/ghc/ticket/14794#ticket
+    -Wno-missing-exported-signatures
+    -- Requires explicit export lists for every module, a pain for large modules
+    -Wno-missing-export-lists
+    -- Requires explicit imports of _every_ function (e.g. '$'); too strict
+    -Wno-missing-import-lists
+    -- When GHC can't specialize a polymorphic function. No big deal and requires fixing underlying libraries to solve.
+    -Wno-missed-specialisations
+    -- See missed-specialisations
+    -Wno-all-missed-specialisations
+    -- Don't use Safe Haskell warnings
+    -Wno-unsafe
+    -- Warning for polymorphic local bindings. Don't think this is an issue
+    -Wno-missing-local-signatures
+    -- Don't warn if the monomorphism restriction is used
+    -Wno-monomorphism-restriction
+    --  Cabal isn’t setting this currently (introduced in GHC 8.10)
+    -Wno-missing-safe-haskell-mode
+    --  Cabal’s generate Path_*.hs doesn’t do this (fixed in https://github.com/haskell/cabal/pull/7352)
+    -Wno-prepositive-qualified-module
+    -- Some tooling gives this error
+    -Wno-unused-packages
+    -- Warns on every single data declaration
+    -Wno-missing-kind-signatures
+
+  default-extensions:
+    AllowAmbiguousTypes
+    ApplicativeDo
+    BlockArguments
+    DataKinds
+    DeriveAnyClass
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingVia
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    GADTs
+    GeneralizedNewtypeDeriving
+    ImportQualifiedPost
+    InstanceSigs
+    LambdaCase
+    LexicalNegation
+    MonoLocalBinds
+    MultiWayIf
+    NamedFieldPuns
+    NumericUnderscores
+    NoImplicitPrelude
+    OverloadedStrings
+    PatternSynonyms
+    PolyKinds
+    RankNTypes
+    RecordWildCards
+    RecursiveDo
+    ScopedTypeVariables
+    StandaloneDeriving
+    StandaloneKindSignatures
+    TypeApplications
+    TypeFamilies
+    ViewPatterns
 
 library
+  import: build-opts
   hs-source-dirs:
       src
   exposed-modules:
@@ -43,6 +109,7 @@ library
       Web.Slack.User
   other-modules:
       Web.Slack.Util
+      Web.Slack.Prelude
   build-depends:
       aeson >= 2.0 && < 2.2
     , base >= 4.11 && < 4.18
@@ -50,7 +117,10 @@ library
     , containers
     , deepseq
     , unordered-containers
+    , mono-traversable
+    , classy-prelude
     , hashable
+    , string-conversions
     , http-api-data >= 0.3 && < 0.6
     , http-client >= 0.5 && < 0.8
     , http-client-tls >= 0.3 && < 0.4

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -103,6 +103,7 @@ library
       Web.Slack.Classy
       Web.Slack.Common
       Web.Slack.Conversation
+      Web.Slack.Internal
       Web.Slack.MessageParser
       Web.Slack.Pager
       Web.Slack.Types
@@ -124,9 +125,9 @@ library
     , http-api-data >= 0.3 && < 0.6
     , http-client >= 0.5 && < 0.8
     , http-client-tls >= 0.3 && < 0.4
-    , servant >= 0.12 && < 0.20
-    , servant-client >= 0.12 && < 0.20
-    , servant-client-core >= 0.12 && < 0.20
+    , servant >= 0.16 && < 0.20
+    , servant-client >= 0.16 && < 0.20
+    , servant-client-core >= 0.16 && < 0.20
     , text (>= 1.2 && < 1.3) || (>= 2.0 && < 2.1)
     , transformers
     , mtl

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -72,7 +72,6 @@ common build-opts
     ImportQualifiedPost
     InstanceSigs
     LambdaCase
-    LexicalNegation
     MonoLocalBinds
     MultiWayIf
     NamedFieldPuns

--- a/src/Web/Slack.hs
+++ b/src/Web/Slack.hs
@@ -34,6 +34,9 @@ module Web.Slack
   )
   where
 
+-- FIXME: Web.Slack.Prelude
+import Prelude
+
 -- aeson
 import Data.Aeson
 
@@ -96,7 +99,7 @@ data SlackConfig
 -- constrast with 'SlackClientError' which additionally
 -- contains errors which occured during the network communication.
 data ResponseSlackError = ResponseSlackError Text
-  deriving (Eq, Show)
+  deriving stock (Eq, Show)
 
 
 -- |

--- a/src/Web/Slack/Api.hs
+++ b/src/Web/Slack/Api.hs
@@ -19,6 +19,9 @@ module Web.Slack.Api
   )
   where
 
+-- FIXME: Web.Slack.Prelude
+import Prelude
+
 -- aeson
 import Data.Aeson.TH
 
@@ -47,7 +50,7 @@ data TestReq =
     { testReqError :: Maybe Text
     , testReqFoo :: Maybe Text
     }
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show)
 
 instance NFData TestReq
 
@@ -88,7 +91,7 @@ data TestRsp =
   TestRsp
     { testRspArgs :: Maybe TestReq
     }
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show)
 
 instance NFData TestRsp
 

--- a/src/Web/Slack/Auth.hs
+++ b/src/Web/Slack/Auth.hs
@@ -15,6 +15,9 @@
 module Web.Slack.Auth
   where
 
+-- FIXME: Web.Slack.Prelude
+import Prelude
+
 -- aeson
 import Data.Aeson.TH
 
@@ -44,7 +47,7 @@ data TestRsp =
     , testRspUserId :: Text
     , testRspEnterpriseId :: Maybe Text
     }
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show)
 
 instance NFData TestRsp
 

--- a/src/Web/Slack/Chat.hs
+++ b/src/Web/Slack/Chat.hs
@@ -19,6 +19,9 @@ module Web.Slack.Chat
   )
   where
 
+-- FIXME: Web.Slack.Prelude
+import Prelude
+
 -- aeson
 import Data.Aeson.TH
 
@@ -53,7 +56,7 @@ data PostMsg =
     , postMsgThreadTs :: Maybe Text
     , postMsgReplyBroadcast :: Maybe Bool
     }
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show)
 
 instance NFData PostMsg
 
@@ -86,7 +89,7 @@ data PostMsgReq =
     , postMsgReqThreadTs :: Maybe Text
     , postMsgReqReplyBroadcast :: Maybe Bool
     }
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show)
 
 instance NFData PostMsgReq
 
@@ -143,7 +146,7 @@ data PostMsgRsp =
     { postMsgRspTs :: String
     , postMsgRspMessage :: PostMsg
     }
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show)
 
 instance NFData PostMsgRsp
 

--- a/src/Web/Slack/Classy.hs
+++ b/src/Web/Slack/Classy.hs
@@ -34,6 +34,9 @@ module Web.Slack.Classy
   )
   where
 
+-- FIXME: Web.Slack.Prelude
+import Prelude
+
 -- base
 import Control.Arrow ((&&&))
 import Data.Maybe

--- a/src/Web/Slack/Common.hs
+++ b/src/Web/Slack/Common.hs
@@ -33,6 +33,9 @@ module Web.Slack.Common
   )
   where
 
+-- FIXME: Web.Slack.Prelude
+import Prelude
+
 -- aeson
 import Data.Aeson
 import Data.Aeson.TH
@@ -60,7 +63,7 @@ type ClientError = ServantError
 #endif
 
 data MessageType = MessageTypeMessage
-  deriving (Eq, Show, Generic)
+  deriving stock (Eq, Show, Generic)
 
 instance NFData MessageType
 
@@ -80,7 +83,7 @@ data Message =
     -- Use 'Web.Slack.MessageParser.messageToHtml' to convert it to HTML.
     , messageTs :: SlackTimestamp
     }
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show)
 
 instance NFData Message
 
@@ -93,7 +96,7 @@ data SlackClientError
     -- ^ errors from the network connection
     | SlackError Text
     -- ^ errors returned by the slack API
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show)
 
 instance NFData SlackClientError
 

--- a/src/Web/Slack/Conversation.hs
+++ b/src/Web/Slack/Conversation.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE RecordWildCards #-}
+-- FIXME: squashes warnings
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
 ----------------------------------------------------------------------
 -- |
@@ -35,6 +37,9 @@ module Web.Slack.Conversation
   , mkRepliesReq
   , ResponseMetadata (..)
   ) where
+
+-- FIXME: Web.Slack.Prelude
+import Prelude
 
 -- aeson
 import Data.Aeson
@@ -75,7 +80,7 @@ data Topic =
     , topicCreator :: Text
     , topicLastSet :: Integer
     }
-  deriving (Eq, Show, Generic)
+  deriving stock (Eq, Show, Generic)
 
 instance NFData Topic
 
@@ -91,7 +96,7 @@ data Purpose =
     , purposeCreator :: Text
     , purposeLastSet :: Integer
     }
-  deriving (Eq, Show, Generic)
+  deriving stock (Eq, Show, Generic)
 
 instance NFData Purpose
 
@@ -136,7 +141,7 @@ data ChannelConversation =
     , channelPreviousNames :: [Text]
     , channelNumMembers :: Integer
     }
-  deriving (Eq, Show, Generic)
+  deriving stock (Eq, Show, Generic)
 
 instance NFData ChannelConversation
 
@@ -186,7 +191,7 @@ data GroupConversation =
     , groupPurpose :: Purpose
     , groupPriority :: Scientific
     }
-  deriving (Eq, Show, Generic)
+  deriving stock (Eq, Show, Generic)
 
 instance NFData GroupConversation
 
@@ -205,7 +210,7 @@ data ImConversation =
     , imIsUserDeleted :: Bool
     , imPriority :: Scientific
     }
-  deriving (Eq, Show, Generic)
+  deriving stock (Eq, Show, Generic)
 
 instance NFData ImConversation
 
@@ -219,7 +224,7 @@ data Conversation =
       Channel ChannelConversation
     | Group GroupConversation
     | Im ImConversation
-  deriving (Eq, Show, Generic)
+  deriving stock (Eq, Show, Generic)
 
 instance NFData Conversation
 
@@ -266,7 +271,7 @@ data ConversationType =
   | PrivateChannelType
   | MpimType
   | ImType
-  deriving (Eq, Show, Generic)
+  deriving stock (Eq, Show, Generic)
 
 instance NFData ConversationType
 
@@ -297,7 +302,7 @@ data ListReq =
     { listReqExcludeArchived :: Maybe Bool
     , listReqTypes :: [ConversationType]
     }
-  deriving (Eq, Show, Generic)
+  deriving stock (Eq, Show, Generic)
 
 instance NFData ListReq
 
@@ -344,7 +349,7 @@ newtype ListRsp =
   ListRsp
     { listRspChannels :: [Conversation]
     }
-  deriving (Eq, Show, Generic)
+  deriving stock (Eq, Show, Generic)
 
 instance NFData ListRsp
 
@@ -363,7 +368,7 @@ data HistoryReq =
     , historyReqOldest :: Maybe SlackTimestamp
     , historyReqInclusive :: Bool
     }
-  deriving (Eq, Show, Generic)
+  deriving stock (Eq, Show, Generic)
 
 instance NFData HistoryReq
 
@@ -410,7 +415,7 @@ instance ToForm HistoryReq where
 --
 --
 newtype ResponseMetadata = ResponseMetadata { responseMetadataNextCursor :: Maybe Cursor }
-  deriving (Eq, Show, Generic)
+  deriving stock (Eq, Show, Generic)
 
 instance NFData ResponseMetadata
 
@@ -426,7 +431,7 @@ data HistoryRsp =
     { historyRspMessages :: [Message]
     , historyRspResponseMetadata :: Maybe ResponseMetadata
     }
-  deriving (Eq, Show, Generic)
+  deriving stock (Eq, Show, Generic)
 
 instance NFData HistoryRsp
 
@@ -443,7 +448,7 @@ data RepliesReq =
     , repliesReqOldest :: Maybe SlackTimestamp
     , repliesReqInclusive :: Bool
     }
-  deriving (Eq, Show, Generic)
+  deriving stock (Eq, Show, Generic)
 
 instance NFData RepliesReq
 

--- a/src/Web/Slack/Internal.hs
+++ b/src/Web/Slack/Internal.hs
@@ -1,0 +1,66 @@
+-- | Internal things in slack-web. May be changed arbitrarily!
+module Web.Slack.Internal where
+
+import Data.Aeson (Value (..))
+import Network.HTTP.Client (Manager)
+import Servant.API hiding (addHeader)
+
+-- import Servant.Client.Core
+
+import Servant.Client (BaseUrl (..), ClientM, Scheme (..), runClientM, ClientError, mkClientEnv)
+import Servant.Client.Core (AuthClientData, AuthenticatedRequest, Request, mkAuthenticatedRequest, addHeader)
+import Web.Slack.Pager (Response)
+import Web.Slack.Prelude
+import qualified Web.Slack.Common as Common
+
+data SlackConfig = SlackConfig
+  { slackConfigManager :: Manager
+  , slackConfigToken :: Text
+  }
+
+-- contains errors that can be returned by the slack API.
+-- constrast with 'SlackClientError' which additionally
+-- contains errors which occured during the network communication.
+data ResponseSlackError = ResponseSlackError Text
+  deriving stock (Eq, Show)
+
+{- |
+ Internal type!
+-}
+newtype ResponseJSON a = ResponseJSON (Either ResponseSlackError a)
+
+instance FromJSON a => FromJSON (ResponseJSON a) where
+  parseJSON = withObject "Response" $ \o -> do
+    ok <- o .: "ok"
+    ResponseJSON
+      <$> if ok
+        then Right <$> parseJSON (Object o)
+        else Left . ResponseSlackError <$> o .: "error"
+
+mkSlackAuthenticateReq :: SlackConfig -> AuthenticatedRequest (AuthProtect "token")
+mkSlackAuthenticateReq = (`mkAuthenticatedRequest` authenticateReq) . slackConfigToken
+
+type instance
+  AuthClientData (AuthProtect "token") =
+    Text
+
+authenticateReq ::
+  Text ->
+  Request ->
+  Request
+authenticateReq token =
+  addHeader "Authorization" $ "Bearer " <> token
+
+run ::
+  ClientM (ResponseJSON a) ->
+  Manager ->
+  IO (Response a)
+run clientAction mgr = do
+  let baseUrl = BaseUrl Https "slack.com" 443 "/api"
+  unnestErrors <$> liftIO (runClientM clientAction $ mkClientEnv mgr baseUrl)
+
+unnestErrors :: Either ClientError (ResponseJSON a) -> Response a
+unnestErrors (Right (ResponseJSON (Right a))) = Right a
+unnestErrors (Right (ResponseJSON (Left (ResponseSlackError serv)))) =
+  Left (Common.SlackError serv)
+unnestErrors (Left slackErr) = Left (Common.ServantError slackErr)

--- a/src/Web/Slack/MessageParser.hs
+++ b/src/Web/Slack/MessageParser.hs
@@ -12,9 +12,12 @@ module Web.Slack.MessageParser
   )
   where
 
+-- FIXME: Web.Slack.Prelude
+import Prelude
+
 -- base
 import Control.Monad
-import Data.List
+import Data.List ( intercalate )
 import Data.Maybe
 import Data.Void
 
@@ -33,7 +36,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 
 newtype SlackUrl = SlackUrl { unSlackUrl :: Text }
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 data SlackMsgItem
   = SlackMsgItemPlainText Text
@@ -46,7 +49,7 @@ data SlackMsgItem
   | SlackMsgItemCodeSection Text
   | SlackMsgItemQuoted [SlackMsgItem]
   | SlackMsgItemEmoticon Text
-  deriving (Show, Eq)
+  deriving stock (Show, Eq)
 
 #if MIN_VERSION_megaparsec(6,0,0)
 type MegaparsecError = Void
@@ -99,7 +102,7 @@ sectionEndSymbol :: Char -> SlackParser ()
 sectionEndSymbol chr = void $ char chr >> lookAhead wordBoundary
 
 parseCharDelimitedSection :: Char -> SlackParser [SlackMsgItem]
-parseCharDelimitedSection chr = 
+parseCharDelimitedSection chr =
   char chr *> someTill (parseMessageItem False) (sectionEndSymbol chr)
 
 wordBoundary :: SlackParser ()
@@ -184,7 +187,7 @@ defaultHtmlRenderers :: HtmlRenderers
 defaultHtmlRenderers = HtmlRenderers
   { emoticonRenderer = \code -> ":" <> code <> ":"
   }
-  
+
 msgItemToHtml :: HtmlRenderers -> (UserId -> Text) -> SlackMsgItem -> Text
 msgItemToHtml htmlRenderers@HtmlRenderers{..} getUserDesc = \case
   SlackMsgItemPlainText txt -> T.replace "\n" "<br/>" txt

--- a/src/Web/Slack/Pager.hs
+++ b/src/Web/Slack/Pager.hs
@@ -12,6 +12,9 @@ module Web.Slack.Pager
   , loadingPage
   ) where
 
+-- FIXME: Web.Slack.Prelude
+import Prelude
+
 -- base
 import           Control.Monad.IO.Class (MonadIO, liftIO)
 import           Data.IORef             (newIORef, readIORef, writeIORef)

--- a/src/Web/Slack/Prelude.hs
+++ b/src/Web/Slack/Prelude.hs
@@ -1,0 +1,12 @@
+module Web.Slack.Prelude
+  ( module ClassyPrelude,
+    module Data.Aeson,
+    module Data.Aeson.TH,
+    cs,
+  )
+where
+
+import ClassyPrelude hiding (link)
+import Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.:), (.:?), (.=))
+import Data.Aeson.TH (deriveJSON)
+import Data.String.Conversions (cs)

--- a/src/Web/Slack/Types.hs
+++ b/src/Web/Slack/Types.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE TypeApplications #-}
-
 ----------------------------------------------------------------------
 -- |
 -- Module: Web.Slack.Types
@@ -26,30 +20,22 @@ module Web.Slack.Types
   )
   where
 
+import Web.Slack.Prelude
+
 -- aeson
 import Data.Aeson
-
--- base
-import Data.Bifunctor (second)
-import GHC.Generics (Generic)
-
--- deepseq
-import Control.DeepSeq (NFData)
-
--- hashable
-import Data.Hashable (Hashable)
 
 -- http-api-data
 import Web.HttpApiData
 
 -- text
-import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Read (rational)
 
 -- time
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
+import Control.Monad (MonadFail(..))
 
 -- Ord to allow it to be a key of a Map
 newtype Color = Color { unColor :: Text }

--- a/src/Web/Slack/User.hs
+++ b/src/Web/Slack/User.hs
@@ -21,6 +21,9 @@ module Web.Slack.User
   )
   where
 
+-- FIXME: Web.Slack.Prelude
+import Prelude
+
 -- aeson
 import Data.Aeson.TH
 
@@ -43,25 +46,25 @@ import Web.FormUrlEncoded
 
 -- See https://api.slack.com/types/user
 
-data Profile = 
-  Profile 
+data Profile =
+  Profile
     { profileAvatarHash :: Maybe Text
     , profileStatusText :: Maybe Text
-    , profileStatusEmoji :: Maybe Text 
-    , profileRealName :: Maybe Text 
-    , profileDisplayName :: Maybe Text 
-    , profileRealNameNormalized :: Maybe Text 
-    , profileDisplayNameNormalized :: Maybe Text 
-    , profileEmail :: Maybe Text 
-    , profileImage_24 :: Text 
-    , profileImage_32 :: Text 
-    , profileImage_48 :: Text 
-    , profileImage_72 :: Text 
-    , profileImage_192 :: Text 
-    , profileImage_512 :: Text 
-    , profileTeam :: Maybe Text 
+    , profileStatusEmoji :: Maybe Text
+    , profileRealName :: Maybe Text
+    , profileDisplayName :: Maybe Text
+    , profileRealNameNormalized :: Maybe Text
+    , profileDisplayNameNormalized :: Maybe Text
+    , profileEmail :: Maybe Text
+    , profileImage_24 :: Text
+    , profileImage_32 :: Text
+    , profileImage_48 :: Text
+    , profileImage_72 :: Text
+    , profileImage_192 :: Text
+    , profileImage_512 :: Text
+    , profileTeam :: Maybe Text
     }
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show)
 
 $(deriveFromJSON (jsonOpts "profile") ''Profile)
 
@@ -79,7 +82,7 @@ data User =
     , userIsUltraRestricted :: Maybe Bool
     , userUpdated :: POSIXTime
     }
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show)
 
 $(deriveFromJSON (jsonOpts "user") ''User)
 
@@ -87,7 +90,7 @@ data ListRsp =
   ListRsp
     { listRspMembers :: [User]
     }
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show)
 
 $(deriveFromJSON (jsonOpts "listRsp") ''ListRsp)
 
@@ -96,11 +99,11 @@ data UserRsp =
   UserRsp
     { userRspUser :: User
     }
-  deriving (Eq, Generic, Show)
+  deriving stock (Eq, Generic, Show)
 
 $(deriveFromJSON (jsonOpts "UserRsp") ''UserRsp)
 
-newtype Email = Email Text deriving (Eq, Generic, Show)
-instance ToForm Email where 
+newtype Email = Email Text deriving stock (Eq, Generic, Show)
+instance ToForm Email where
   toForm (Email txt) = [("email", toQueryParam txt)]
 

--- a/src/Web/Slack/Util.hs
+++ b/src/Web/Slack/Util.hs
@@ -14,6 +14,9 @@ module Web.Slack.Util
   )
   where
 
+-- FIXME: Web.Slack.Prelude
+import Prelude
+
 -- aeson
 import Data.Aeson.TH
 import Data.Aeson.Types


### PR DESCRIPTION
The internal module is necessary to allow extending the library, and the warnings improve reliability.