### PR TITLE
Upstream Mercury Slack blocks code

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,8 +83,8 @@
             # it's not yet in hackage2nix
             string-variants = hfinal.callHackageDirect {
               pkg = "string-variants";
-              ver = "0.1.0.0";
-              sha256 = "sha256-4MJAZmlCx9GeNzpW93BNjL8Q9kCUDxWi+1cz7Vycxng=";
+              ver = "0.1.0.1";
+              sha256 = "sha256-7oNYwPP8xRNYxKNdNH+21zBHdeUeiWBtKOK5G43xtSQ=";
             } {};
           });
       };

--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,13 @@
             # and the fourmolu/ormolu bug:
             # https://github.com/tweag/ormolu/issues/927
             mutable-containers = hlib.dontCheck hprev.mutable-containers;
+
+            # it's not yet in hackage2nix
+            string-variants = hfinal.callHackageDirect {
+              pkg = "string-variants";
+              ver = "0.1.0.0";
+              sha256 = "sha256-4MJAZmlCx9GeNzpW93BNjL8Q9kCUDxWi+1cz7Vycxng=";
+            } {};
           });
       };
     };

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,0 +1,13 @@
+indentation: 2
+comma-style: leading # 'leading' or 'trailing'
+record-brace-space: true # rec {x = 1} vs. rec{x = 1}
+indent-wheres: true # 'false' means save space by only half-indenting the 'where' keyword
+diff-friendly-import-export: false # 'false' uses Ormolu-style lists
+respectful: false # don't be too opinionated about newlines etc.
+haddock-style: single-line # 'signle-line' or 'multi-line', i.e., '--' vs. '{-'
+newlines-between-decls: 1 # number of newlines between top-level declarations
+
+fixities:
+  - 'infixl 9 .:'
+  - 'infixl 9 .:?'
+  - 'infixr 8 .='

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -107,32 +107,38 @@ library
       Web.Slack.Pager
       Web.Slack.Types
       Web.Slack.User
+      Web.Slack.Experimental.Blocks
+      Web.Slack.Experimental.Blocks.Types
   other-modules:
       Web.Slack.Util
       Web.Slack.Prelude
+      Web.Slack.AesonUtils
   build-depends:
       aeson >= 2.0 && < 2.2
     , base >= 4.11 && < 4.18
-    , scientific
+    , classy-prelude
     , containers
     , deepseq
-    , unordered-containers
-    , mono-traversable
-    , classy-prelude
+    , errors
     , hashable
-    , string-conversions
     , http-api-data >= 0.3 && < 0.6
     , http-client >= 0.5 && < 0.8
     , http-client-tls >= 0.3 && < 0.4
+    , megaparsec >= 5.0 && < 10
+    , mono-traversable
+    , mtl
+    , refined
+    , scientific
     , servant >= 0.16 && < 0.20
     , servant-client >= 0.16 && < 0.20
     , servant-client-core >= 0.16 && < 0.20
+    , string-conversions
+    , string-variants
     , text (>= 1.2 && < 1.3) || (>= 2.0 && < 2.1)
-    , transformers
-    , mtl
     , time
-    , errors
-    , megaparsec >= 5.0 && < 10
+    , transformers
+    , unordered-containers
+    , vector
   default-language:
       Haskell2010
   ghc-options:

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -133,7 +133,7 @@ library
     , servant-client >= 0.16 && < 0.20
     , servant-client-core >= 0.16 && < 0.20
     , string-conversions
-    , string-variants
+    , string-variants >= 0.1.0.1
     , text (>= 1.2 && < 1.3) || (>= 2.0 && < 2.1)
     , time
     , transformers

--- a/src/Web/Slack/AesonUtils.hs
+++ b/src/Web/Slack/AesonUtils.hs
@@ -1,0 +1,100 @@
+module Web.Slack.AesonUtils where
+
+import Data.Aeson
+import Data.Char qualified as Char
+import Data.Text qualified as T
+import Web.Slack.Prelude
+import Data.Aeson.Types (Pair)
+import qualified Data.Aeson as J
+
+-- | Checks that a record's field labels each start with the given 'prefix',
+-- then uses a given 'drop (length prefix)' derivingStrategy to drop that prefix from generated JSON.
+--
+-- If used in a Template Haskell splice, gives a compile-time error if the prefixes don't match up.
+-- Warning: This function should not be used outside of a Template Haskell splice, as it calls `error` in the case that the prefixes don't match up!
+--
+-- Example usage:
+--
+-- data PrefixedRecord = PrefixedRecord { prefixedRecordOne :: Int, prefixedRecordTwo :: Char }
+
+-- $(deriveFromJSON (jsonDeriveWithAffix "prefixedRecord" jsonDeriveOptionsSnakeCase) ''PrefixedRecord)
+
+jsonDeriveWithAffix :: Text -> (Int -> Options) -> Options
+jsonDeriveWithAffix prefix derivingStrategy =
+  originalOptions
+    { fieldLabelModifier = \fieldLabel ->
+        if prefix `isPrefixOf` T.pack fieldLabel
+          then originalModifier fieldLabel
+          else error $ "Prefixes don't match: `" <> T.unpack prefix <> "` isn't a prefix of `" <> fieldLabel <> "`. Search for jsonDeriveWithAffix to learn more."
+    }
+  where
+    originalOptions = derivingStrategy $ T.length prefix
+    originalModifier = fieldLabelModifier originalOptions
+
+camelToSnake :: String -> String
+camelToSnake = camelTo2 '_'
+
+lowerFirst :: String -> String
+lowerFirst [] = []
+lowerFirst (c : chars) = Char.toLower c : chars
+
+jsonDeriveOptionsSnakeCase :: Int -> Options
+jsonDeriveOptionsSnakeCase n =
+  defaultOptions
+    { fieldLabelModifier = camelToSnake . lowerFirst . drop n
+    , omitNothingFields = True
+    , constructorTagModifier = camelToSnake . lowerFirst . drop n
+    }
+
+-- | Create a 'Value' from a list of name\/value @Maybe Pair@'s.
+-- For 'Nothing', instead of outputting @null@, that field will not be output at all.
+-- If duplicate keys arise, later keys and their associated values win.
+--
+-- Example:
+--
+-- @
+-- objectOptional
+--   [ "always" .=! 1
+--   , "just" .=? Just 2
+--   , "nothing" .=? Nothing
+--   ]
+-- @
+--
+-- will result in the JSON
+--
+-- @
+-- {
+--   "always": 1,
+--   "just": 2
+-- }
+-- @
+--
+-- The field @nothing@ is ommited because it was 'Nothing'.
+objectOptional :: [Maybe Pair] -> Value
+objectOptional = J.object . catMaybes
+
+-- | Encode a value for 'objectOptional'
+(.=!) :: ToJSON v => Key -> v -> Maybe Pair
+key .=! val = Just (key .= val)
+
+infixr 8 .=!
+
+-- | Encode a Maybe value for 'objectOptional'
+(.=?) :: ToJSON v => Key -> Maybe v -> Maybe Pair
+key .=? mVal = fmap (key .=) mVal
+
+infixr 8 .=?
+
+-- | Conditionally encode a value for 'objectOptional'
+(?.>) :: Bool -> Pair -> Maybe Pair
+True ?.> pair = Just pair
+False ?.> _ = Nothing
+
+infixr 7 ?.>
+
+-- | Conditionally express a pair in a JSON series
+thenPair :: Bool -> J.Series -> J.Series
+thenPair True s = s
+thenPair False _ = mempty
+
+infixr 7 `thenPair`

--- a/src/Web/Slack/Experimental/Blocks.hs
+++ b/src/Web/Slack/Experimental/Blocks.hs
@@ -1,0 +1,193 @@
+module Web.Slack.Experimental.Blocks
+  ( -- * General Slack Messages
+    SlackText,
+    (<+>),
+    parens,
+    brackets,
+    angleBrackets,
+    ticks,
+    codeBlock,
+    bold,
+    newline,
+    unorderedList,
+    link,
+    monospaced,
+    mentionUser,
+    isSubStringOf,
+    SlackImage (..),
+    SlackMessage,
+    Markdown (..),
+    Image (..),
+    context,
+    textToMessage,
+    prefixFirstSlackMessage,
+    mentionUserGroupById,
+    textToContext,
+    slackMessage,
+    SlackBlock (..),
+
+    -- * Rendered messages
+    RenderedSlackMessage (..),
+    render,
+
+    -- * Introduction to Slack Interactive Messages
+    -- $interactive
+
+    -- * Creating Slack Interactive Messages
+    actions,
+    actionsWithBlockId,
+    SlackActionId (..),
+    SlackBlockId,
+    setting,
+    emptySetting,
+    SlackStyle (..),
+    plaintext,
+    plaintextonly,
+    mrkdwn,
+    button,
+    buttonSettings,
+    ButtonSettings
+      ( buttonUrl,
+        buttonValue,
+        buttonStyle,
+        buttonConfirm
+      ),
+    confirm,
+    confirmAreYouSure,
+    ConfirmSettings
+      ( confirmTitle,
+        confirmText,
+        confirmConfirm,
+        confirmDeny,
+        confirmStyle
+      ),
+
+    -- * Responding to Slack Interactive Messages
+    SlackInteractiveResponse (..),
+  )
+where
+
+import Data.Aeson.Text (encodeToLazyText)
+import Data.Text qualified as T
+import Web.Slack.Experimental.Blocks.Types
+import Web.Slack.Prelude
+import Web.Slack.Types
+
+(<+>) :: SlackText -> SlackText -> SlackText
+x <+> y = x <> " " <> y
+
+parens :: SlackText -> SlackText
+parens x = "(" <> x <> ")"
+
+brackets :: SlackText -> SlackText
+brackets x = "[" <> x <> "]"
+
+angleBrackets :: SlackText -> SlackText
+angleBrackets x = "<" <> x <> ">"
+
+ticks :: SlackText -> SlackText
+ticks x = "`" <> x <> "`"
+
+-- | Render a 'Slack' renderable value with ticks around it. Alias for @ticks . message@
+monospaced :: Slack a => a -> SlackText
+monospaced = ticks . message
+
+codeBlock :: SlackText -> SlackText
+codeBlock x = "```\n" <> x <> "\n```"
+
+bold :: SlackText -> SlackText
+bold x = "*" <> x <> "*"
+
+newline :: SlackText -> SlackText
+newline x = "\n" <> x
+
+-- | Render an unordered (bulleted) list
+unorderedList :: [SlackText] -> SlackText
+unorderedList = mconcat . fmap (\t -> newline (message @Text "- " <> t))
+
+-- | https://api.slack.com/reference/surfaces/formatting#mentioning-users
+mentionUser :: UserId -> SlackText
+mentionUser slackUserId = message $ "<@" <> unUserId slackUserId <> ">"
+
+-- | https://api.slack.com/reference/surfaces/formatting#mentioning-groups
+mentionUserGroupById :: SlackText -> SlackText
+mentionUserGroupById userGroupId = angleBrackets $ "!subteam^" <> userGroupId
+
+isSubStringOf :: Text -> SlackText -> Bool
+needle `isSubStringOf` (SlackText haystack) = needle `isInfixOf` concat haystack
+
+-- | RenderedSlackMessage contains the original SlackMessage, the rendered version, and a
+--   boolean indicating whether truncation was done.
+--
+--   Usage:
+--
+--   @
+--      let
+--        msg =
+--        (mkPostMsgReq channel "")
+--          { postMsgReqBlocks = Just blocks
+--          , postMsgReqThreadTs = mThreadTs
+--          }
+--    chatPostMessage msg
+--   @
+data RenderedSlackMessage = RenderedSlackMessage
+  { _originalMessage :: SlackMessage
+  , _renderedMessage :: Text
+  , _truncated :: Bool
+  }
+
+render :: SlackMessage -> RenderedSlackMessage
+render sm =
+  let (truncatedSm, isTruncated) = truncateSlackMessage sm
+   in RenderedSlackMessage sm (cs . encodeToLazyText . toJSON $ truncatedSm) isTruncated
+
+-- | Slack will fail if any text block is over 3000 chars.
+--   truncateSlackMessage will truncate all text blocks and also return an bool
+--   indicating whether any truncation was done.
+truncateSlackMessage :: SlackMessage -> (SlackMessage, Bool)
+truncateSlackMessage (SlackMessage blocks) =
+  let (truncatedBlocks, isTruncateds) = unzip $ map truncateSlackBlock blocks
+   in (SlackMessage truncatedBlocks, or isTruncateds)
+
+truncateSlackBlock :: SlackBlock -> (SlackBlock, Bool)
+truncateSlackBlock sb@(SlackBlockSection (SlackText texts)) =
+  let messageLength = sum $ map T.length texts
+      lengthLimit = 3000
+      truncationMessage = "\n...Rest of message truncated for slack\n"
+      truncationMessageLength = T.length truncationMessage
+      truncateTexts ts = take (lengthLimit - truncationMessageLength) (concat ts)
+   in if messageLength > lengthLimit
+        then (SlackBlockSection (SlackText [truncateTexts texts <> "\n...Rest of message truncated for slack\n"]), True)
+        else (sb, False)
+-- possible to also truncate SlackContexts, but we never put long strings in there.
+truncateSlackBlock x = (x, False)
+
+prefixFirstSlackBlockSection :: Text -> [SlackBlock] -> ([SlackBlock], Bool)
+prefixFirstSlackBlockSection prefix (SlackBlockSection slackBlockSection : sbs) = (SlackBlockSection (message prefix <> slackBlockSection) : sbs, True)
+prefixFirstSlackBlockSection prefix (sb : sbs) = let (prefixedSbs, match) = prefixFirstSlackBlockSection prefix sbs in (sb : prefixedSbs, match)
+prefixFirstSlackBlockSection _ [] = ([], False)
+
+prefixFirstSlackMessage :: Text -> [SlackMessage] -> [SlackMessage]
+prefixFirstSlackMessage prefix (sm : sms) =
+  let SlackMessage slackBlocks = sm
+      (prefixedSlackBlocks, match) = prefixFirstSlackBlockSection prefix slackBlocks
+   in if match
+        then SlackMessage prefixedSlackBlocks : sms
+        else sm : prefixFirstSlackMessage prefix sms
+prefixFirstSlackMessage _ [] = []
+
+-- | Concatenate a list of 'SlackText' into a single block, and wrap it up as a full message
+slackMessage :: [SlackText] -> SlackMessage
+slackMessage = SlackMessage . pure . SlackBlockSection . mconcat
+
+-- $interactive
+--
+-- = Slack Interactive Messages
+--
+-- First, familiarize yourself with [Slack's Interactivity documentation](https://api.slack.com/interactivity).
+-- Currently we only support [Block Kit interactive components](https://api.slack.com/interactivity/components),
+-- i.e. components like buttons attached to messages.
+--
+-- To make an Slack message interactive, you need to include an \"Actions\" block that has one or more interactive components.
+-- These should generally only be created using the builder functions such as 'actions' and 'button'. Consumers of this module
+-- should avoid directly importing "Web.Slack.Experimental.Blocks.Types".

--- a/src/Web/Slack/Experimental/Blocks/Types.hs
+++ b/src/Web/Slack/Experimental/Blocks/Types.hs
@@ -1,0 +1,615 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Web.Slack.Experimental.Blocks.Types where
+
+import Control.Monad (MonadFail (..))
+import Data.Aeson (Object, Value (..), withArray)
+import Data.StringVariants
+import Data.Vector qualified as V
+import Refined
+import Refined.Unsafe (reallyUnsafeRefine)
+import Web.Slack.AesonUtils
+import Web.Slack.Prelude
+
+-- | Class of types that can be turned into part of a Slack Message. 'message'
+-- is the primary way of converting primitive and domain-level types into things
+-- that can be shown in a slack message.
+class Slack a where
+  message :: a -> SlackText
+
+newtype SlackText = SlackText {unSlackTexts :: [Text]}
+  deriving newtype (Semigroup, Monoid, Eq)
+
+-- | Render a link with optional link text
+link :: Text -> Maybe Text -> SlackText
+link uri = \case
+  Nothing -> message $ "<" <> uri <> ">"
+  Just linkText -> message $ "<" <> uri <> "|" <> linkText <> ">"
+
+data SlackPlainTextOnly = SlackPlainTextOnly SlackText
+  deriving stock (Eq, Show)
+
+instance IsString SlackPlainTextOnly where
+  fromString = SlackPlainTextOnly . message
+
+instance ToJSON SlackPlainTextOnly where
+  toJSON (SlackPlainTextOnly (SlackText arr)) =
+    object
+      [ "type" .= ("plain_text" :: Text)
+      , "text" .= intercalate "\n" arr
+      ]
+
+instance FromJSON SlackPlainTextOnly where
+  parseJSON = withObject "SlackPlainTextOnly" $ \obj -> do
+    text <- obj .: "text"
+    pure . SlackPlainTextOnly . SlackText $ lines text
+
+-- | Create a 'SlackPlainTextOnly'. Some API points can can take either markdown or plain text,
+-- but some can take only plain text. This enforces the latter.
+plaintextonly :: Slack a => a -> SlackPlainTextOnly
+plaintextonly a = SlackPlainTextOnly $ message a
+
+data SlackTextObject
+  = SlackPlainText SlackText
+  | SlackMarkdownText SlackText
+  deriving stock (Eq, Show)
+
+instance ToJSON SlackTextObject where
+  toJSON (SlackPlainText (SlackText arr)) =
+    object
+      [ "type" .= ("plain_text" :: Text)
+      , "text" .= intercalate "\n" arr
+      ]
+  toJSON (SlackMarkdownText (SlackText arr)) =
+    object
+      [ "type" .= ("mrkdwn" :: Text)
+      , "text" .= intercalate "\n" arr
+      ]
+
+-- | Create a plain text 'SlackTextObject' where the API allows either markdown or plain text.
+plaintext :: Slack a => a -> SlackTextObject
+plaintext = SlackPlainText . message
+
+-- | Create a markdown 'SlackTextObject' where the API allows either markdown or plain text.
+mrkdwn :: Slack a => a -> SlackTextObject
+mrkdwn = SlackMarkdownText . message
+
+instance FromJSON SlackTextObject where
+  parseJSON = withObject "SlackTextObject" $ \obj -> do
+    (slackTextType :: Text) <- obj .: "type"
+    case slackTextType of
+      "text" -> do
+        text <- obj .: "text"
+        pure . SlackPlainText . SlackText $ lines text
+      "mrkdwn" -> do
+        text <- obj .: "text"
+        pure . SlackMarkdownText . SlackText $ lines text
+      _ -> fail "Unknown SlackTextObject type, must be one of ['text', 'mrkdwn']"
+
+instance Show SlackText where
+  show (SlackText arr) = show $ concat arr
+
+instance ToJSON SlackText where
+  toJSON (SlackText arr) = toJSON $ concat arr
+
+instance IsString SlackText where
+  fromString = message
+
+instance Slack Text where
+  message text = SlackText [text]
+
+instance Slack String where
+  message = message @Text . pack
+
+instance Slack Int where
+  message = message . show
+
+-- | Represents an optional setting for some Slack Setting.
+newtype OptionalSetting a = OptionalSetting {unOptionalSetting :: Maybe a}
+  deriving newtype (Eq)
+
+-- | Allows using bare Strings without having to use 'setting'
+instance IsString (OptionalSetting String) where
+  fromString = OptionalSetting . Just
+
+-- | Allows using bare Texts without having to use 'setting'
+instance IsString (OptionalSetting Text) where
+  fromString = OptionalSetting . Just . pack
+
+-- | Sets a setting.
+setting :: a -> OptionalSetting a
+setting = OptionalSetting . Just
+
+-- | Sets the empty setting.
+emptySetting :: OptionalSetting a
+emptySetting = OptionalSetting Nothing
+
+-- | Styles for Slack [buttons](https://api.slack.com/reference/block-kit/block-elements#button).
+-- If no style is given, the default style (black) is used.
+data SlackStyle
+  = -- | Green button
+    SlackStylePrimary
+  | -- | Red button
+    SlackStyleDanger
+  deriving stock (Eq, Show)
+
+$(deriveJSON (jsonDeriveWithAffix "SlackStyle" jsonDeriveOptionsSnakeCase) ''SlackStyle)
+
+-- | Used to identify an action. The ID used should be unique among all actions in the block.
+--
+--   This is limited to 255 characters, per the Slack documentation at
+--   <https://api.slack.com/reference/block-kit/block-elements#button>
+newtype SlackActionId = SlackActionId {unSlackActionId :: NonEmptyText 255}
+  deriving stock (Show, Eq)
+  deriving newtype (FromJSON, ToJSON)
+
+-- FIXME(jadel): SlackActionId might be worth turning into something more type
+-- safe: possibly parameterize SlackAction over a sum type parameter
+
+data SlackImage = SlackImage
+  { slackImageTitle :: !(Maybe Text)
+  , slackImageAltText :: !Text
+  -- ^ Optional Title
+  , slackImageUrl :: !Text
+  }
+  deriving stock (Eq)
+
+instance Show SlackImage where
+  show (SlackImage _ altText _) = unpack altText
+
+data SlackContent
+  = SlackContentText SlackText
+  | SlackContentImage SlackImage
+  deriving stock (Eq)
+
+instance Show SlackContent where
+  show (SlackContentText t) = show t
+  show (SlackContentImage i) = show i
+
+instance ToJSON SlackContent where
+  toJSON (SlackContentText t) =
+    object
+      [ "type" .= ("mrkdwn" :: Text)
+      , "text" .= t
+      ]
+  toJSON (SlackContentImage (SlackImage mtitle altText url)) =
+    object $
+      [ "type" .= ("image" :: Text)
+      , "image_url" .= url
+      , "alt_text" .= altText
+      ]
+        <> maybe [] mkTitle mtitle
+    where
+      mkTitle title =
+        [ "title"
+            .= object
+              [ "type" .= ("plain_text" :: Text)
+              , "text" .= title
+              ]
+        ]
+
+instance FromJSON SlackContent where
+  parseJSON = withObject "SlackContent" $ \obj -> do
+    (slackContentType :: Text) <- obj .: "type"
+    case slackContentType of
+      "mrkdwn" -> do
+        (slackContentText :: String) <- obj .: "text"
+        pure $ SlackContentText $ fromString slackContentText
+      "image" -> do
+        (slackImageUrl :: Text) <- obj .: "image_url"
+        (slackImageAltText :: Text) <- obj .: "alt_text"
+        (slackImageTitleObj :: Maybe Object) <- obj .:? "title"
+        (slackImageTitleText :: Maybe Text) <- case slackImageTitleObj of
+          Just innerObj -> innerObj .: "text"
+          Nothing -> pure Nothing
+        pure $ SlackContentImage $ SlackImage slackImageTitleText slackImageAltText slackImageUrl
+      _ -> fail "Unknown SlackContent type, must be one of ['mrkdwn', 'image']"
+
+newtype SlackContext = SlackContext [SlackContent]
+  deriving newtype (Semigroup, Monoid, Eq)
+
+instance Show SlackContext where
+  show (SlackContext arr) = show arr
+
+instance ToJSON SlackContext where
+  toJSON (SlackContext arr) = toJSON arr
+
+instance FromJSON SlackContext where
+  parseJSON = withArray "SlackContext" $ \arr -> do
+    (parsedAsArrayOfSlackContents :: V.Vector SlackContent) <- traverse parseJSON arr
+    let slackContentList = V.toList parsedAsArrayOfSlackContents
+    pure $ SlackContext slackContentList
+
+type SlackActionListConstraints = SizeGreaterThan 0 && SizeLessThan 6
+
+-- | List that enforces that Slack actions must have between 1 and 5 actions.
+newtype SlackActionList = SlackActionList {unSlackActionList :: Refined SlackActionListConstraints [SlackAction]}
+  deriving stock (Show)
+  deriving newtype (Eq, FromJSON, ToJSON)
+
+-- | Helper to allow using up to a 5-tuple for a 'SlackActionList'
+class ToSlackActionList a where
+  toSlackActionList :: a -> SlackActionList
+
+instance ToSlackActionList SlackActionList where
+  toSlackActionList = id
+
+instance ToSlackActionList SlackAction where
+  toSlackActionList a = SlackActionList $ reallyUnsafeRefine [a]
+
+instance ToSlackActionList (SlackAction, SlackAction) where
+  toSlackActionList (a, b) = SlackActionList $ reallyUnsafeRefine [a, b]
+
+instance ToSlackActionList (SlackAction, SlackAction, SlackAction) where
+  toSlackActionList (a, b, c) = SlackActionList $ reallyUnsafeRefine [a, b, c]
+
+instance ToSlackActionList (SlackAction, SlackAction, SlackAction, SlackAction) where
+  toSlackActionList (a, b, c, d) = SlackActionList $ reallyUnsafeRefine [a, b, c, d]
+
+instance ToSlackActionList (SlackAction, SlackAction, SlackAction, SlackAction, SlackAction) where
+  toSlackActionList (a, b, c, d, e) = SlackActionList $ reallyUnsafeRefine [a, b, c, d, e]
+
+data SlackBlock
+  = SlackBlockSection SlackText
+  | SlackBlockImage SlackImage
+  | SlackBlockContext SlackContext
+  | SlackBlockDivider
+  | SlackBlockActions (Maybe SlackBlockId) SlackActionList -- 1 to 5 elements
+  deriving stock (Eq)
+
+instance Show SlackBlock where
+  show (SlackBlockSection t) = show t
+  show (SlackBlockImage i) = show i
+  show (SlackBlockContext contents) = show contents
+  show SlackBlockDivider = "|"
+  show (SlackBlockActions mBlockId as) =
+    show $
+      mconcat
+        [ "actions("
+        , show mBlockId
+        , ") = ["
+        , show $ intercalate ", " (map show (unrefine $ unSlackActionList as))
+        , "]"
+        ]
+
+instance ToJSON SlackBlock where
+  toJSON (SlackBlockSection slackText0) =
+    object
+      [ "type" .= ("section" :: Text)
+      , "text" .= SlackContentText slackText0
+      ]
+  toJSON (SlackBlockImage i) = toJSON (SlackContentImage i)
+  toJSON (SlackBlockContext contents) =
+    object
+      [ "type" .= ("context" :: Text)
+      , "elements" .= contents
+      ]
+  toJSON SlackBlockDivider =
+    object
+      [ "type" .= ("divider" :: Text)
+      ]
+  toJSON (SlackBlockActions mBlockId as) =
+    objectOptional
+      [ "type" .=! ("actions" :: Text)
+      , "block_id" .=? mBlockId
+      , "elements" .=! as
+      ]
+
+instance FromJSON SlackBlock where
+  parseJSON = withObject "SlackBlock" $ \obj -> do
+    (slackBlockType :: Text) <- obj .: "type"
+    case slackBlockType of
+      "section" -> do
+        (sectionContentObj :: Value) <- obj .: "text"
+        SlackContentText sectionContentText <- parseJSON sectionContentObj
+        pure $ SlackBlockSection sectionContentText
+      "context" -> do
+        (contextElementsObj :: Value) <- obj .: "elements"
+        slackContent <- parseJSON contextElementsObj
+        pure $ SlackBlockContext slackContent
+      "image" -> do
+        SlackContentImage i <- parseJSON $ Object obj
+        pure $ SlackBlockImage i
+      "divider" -> pure SlackBlockDivider
+      "actions" -> do
+        slackActions <- obj .: "elements"
+        mBlockId <- obj .:? "block_id"
+        pure $ SlackBlockActions mBlockId slackActions
+      _ -> fail "Unknown SlackBlock type, must be one of ['section', 'context', 'image', 'divider']"
+
+newtype SlackMessage = SlackMessage [SlackBlock]
+  deriving newtype (Semigroup, Monoid, Eq)
+
+instance Show SlackMessage where
+  show (SlackMessage arr) = intercalate " " (map show arr)
+
+instance ToJSON SlackMessage where
+  toJSON (SlackMessage arr) = toJSON arr
+
+instance FromJSON SlackMessage where
+  parseJSON = withArray "SlackMessage" $ \arr -> do
+    (parsedAsArrayOfSlackBlocks :: V.Vector SlackBlock) <- traverse parseJSON arr
+    let slackBlockList = V.toList parsedAsArrayOfSlackBlocks
+    pure $ SlackMessage slackBlockList
+
+textToMessage :: Text -> SlackMessage
+textToMessage = markdown . message
+
+class Markdown a where
+  markdown :: SlackText -> a
+
+instance Markdown SlackMessage where
+  markdown t = SlackMessage [SlackBlockSection t]
+
+instance Markdown SlackContext where
+  markdown t = SlackContext [SlackContentText t]
+
+class Image a where
+  image :: SlackImage -> a
+
+instance Image SlackMessage where
+  image i = SlackMessage [SlackBlockImage i]
+
+instance Image SlackContext where
+  image i = SlackContext [SlackContentImage i]
+
+context :: SlackContext -> SlackMessage
+context c = SlackMessage [SlackBlockContext c]
+
+textToContext :: Text -> SlackMessage
+textToContext = context . markdown . message
+
+-- | Generates interactive components such as buttons.
+actions :: ToSlackActionList as => as -> SlackMessage
+actions as = SlackMessage [SlackBlockActions Nothing $ toSlackActionList as]
+
+-- | Generates interactive components such as buttons with a 'SlackBlockId'.
+actionsWithBlockId :: ToSlackActionList as => SlackBlockId -> as -> SlackMessage
+actionsWithBlockId slackBlockId as = SlackMessage [SlackBlockActions (Just slackBlockId) $ toSlackActionList as]
+
+-- | Settings for [button elements](https://api.slack.com/reference/block-kit/block-elements#button).
+data ButtonSettings = ButtonSettings
+  { buttonUrl :: OptionalSetting (NonEmptyText 3000)
+  -- ^ Optional URL to load into the user's browser.
+  -- However, Slack will still call the webhook and you must send an acknowledgement response.
+  , buttonValue :: OptionalSetting (NonEmptyText 2000)
+  -- ^ Optional value to send with the interaction payload.
+  -- One commoon use is to send state via JSON encoding.
+  , buttonStyle :: OptionalSetting SlackStyle
+  -- ^ Optional 'SlackStyle'. If not provided, uses the default style which is a black button.
+  , buttonConfirm :: OptionalSetting SlackConfirmObject
+  -- ^ An optional confirmation dialog to display.
+  }
+
+-- | Default button settings.
+buttonSettings :: ButtonSettings
+buttonSettings =
+  ButtonSettings
+    { buttonUrl = emptySetting
+    , buttonValue = emptySetting
+    , buttonStyle = emptySetting
+    , buttonConfirm = emptySetting
+    }
+
+-- | Button builder.
+button :: SlackActionId -> SlackButtonText -> ButtonSettings -> SlackAction
+button actionId buttonText ButtonSettings {..} =
+  SlackAction actionId $
+    SlackButton
+      { slackButtonText = buttonText
+      , slackButtonUrl = unOptionalSetting buttonUrl
+      , slackButtonValue = unOptionalSetting buttonValue
+      , slackButtonStyle = unOptionalSetting buttonStyle
+      , slackButtonConfirm = unOptionalSetting buttonConfirm
+      }
+
+-- | Settings for [confirmation dialog objects](https://api.slack.com/reference/block-kit/composition-objects#confirm).
+data ConfirmSettings = ConfirmSettings
+  { confirmTitle :: Text
+  -- ^ Plain text title for the dialog window. Max length 100 characters.
+  , confirmText :: Text
+  -- ^ Markdown explanatory text that appears in the confirm dialog.
+  -- Max length is 300 characters.
+  , confirmConfirm :: Text
+  -- ^ Plain text to display in the \"confirm\" button.
+  -- Max length is 30 characters.
+  , confirmDeny :: Text
+  -- ^ Plain text to display in the \"deny\" button.
+  -- Max length is 30 characters.
+  , confirmStyle :: OptionalSetting SlackStyle
+  -- ^ Optional 'SlackStyle' to use for the \"confirm\" button.
+  }
+
+-- | Default settings for a \"Are you sure?\" confirmation dialog.
+confirmAreYouSure :: ConfirmSettings
+confirmAreYouSure =
+  ConfirmSettings
+    { confirmTitle = "Are You Sure?"
+    , confirmText = "Are you sure you wish to perform this operation?"
+    , confirmConfirm = "Yes"
+    , confirmDeny = "No"
+    , confirmStyle = emptySetting
+    }
+
+-- | Confirm dialog builder.
+confirm :: ConfirmSettings -> SlackConfirmObject
+confirm ConfirmSettings {..} =
+  SlackConfirmObject
+    { slackConfirmTitle = plaintextonly confirmTitle
+    , slackConfirmText = mrkdwn confirmText
+    , slackConfirmConfirm = plaintextonly confirmConfirm
+    , slackConfirmDeny = plaintextonly confirmDeny
+    , slackConfirmStyle = unOptionalSetting confirmStyle
+    }
+
+-- | 'SlackBlockId' should be unique for each message and each iteration
+-- of a message. If a message is updated, use a new block_id.
+type SlackBlockId = NonEmptyText 255
+
+-- | All Slack Actions must have a 'SlackActionId' and one 'SlackActionComponent' (such as a button).
+data SlackAction = SlackAction SlackActionId SlackActionComponent
+  deriving stock (Eq)
+
+instance Show SlackAction where
+  show (SlackAction actionId component) = show actionId <> " " <> show component
+
+-- | [Confirm dialog object](https://api.slack.com/reference/block-kit/composition-objects#confirm).
+data SlackConfirmObject = SlackConfirmObject
+  { slackConfirmTitle :: SlackPlainTextOnly -- max length 100
+  , slackConfirmText :: SlackTextObject -- max length 300
+  , slackConfirmConfirm :: SlackPlainTextOnly -- max length 30
+  , slackConfirmDeny :: SlackPlainTextOnly -- max length 30
+  , slackConfirmStyle :: Maybe SlackStyle
+  }
+  deriving stock (Eq)
+
+instance ToJSON SlackConfirmObject where
+  toJSON SlackConfirmObject {..} =
+    objectOptional
+      [ "title" .=! slackConfirmTitle
+      , "text" .=! slackConfirmText
+      , "confirm" .=! slackConfirmConfirm
+      , "deny" .=! slackConfirmDeny
+      , "style" .=? slackConfirmStyle
+      ]
+
+instance FromJSON SlackConfirmObject where
+  parseJSON = withObject "SlackConfirmObject" $ \obj -> do
+    slackConfirmTitle <- obj .: "title"
+    slackConfirmText <- obj .: "text"
+    slackConfirmConfirm <- obj .: "confirm"
+    slackConfirmDeny <- obj .: "deny"
+    slackConfirmStyle <- obj .:? "style"
+    pure SlackConfirmObject {..}
+
+newtype SlackResponseUrl = SlackResponseUrl {unSlackResponseUrl :: Text}
+  deriving stock (Eq, Show)
+  deriving newtype (FromJSON, ToJSON)
+
+-- | Represents the data we get from a callback from Slack for interactive
+-- operations. See https://api.slack.com/interactivity/handling#payloads
+data SlackInteractivePayload = SlackInteractivePayload
+  { sipUserId :: Text
+  , sipUsername :: Text
+  , sipName :: Text
+  , sipResponseUrl :: Maybe SlackResponseUrl
+  , sipTriggerId :: Maybe Text
+  , sipActions :: [SlackActionResponse]
+  }
+  deriving stock (Show)
+
+instance FromJSON SlackInteractivePayload where
+  parseJSON = withObject "SlackInteractivePayload" $ \obj -> do
+    user <- obj .: "user"
+    sipUserId <- user .: "id"
+    sipUsername <- user .: "username"
+    sipName <- user .: "name"
+    sipResponseUrl <- obj .:? "response_url"
+    sipTriggerId <- obj .:? "trigger_id"
+    actionsObj <- obj .: "actions"
+    sipActions <- parseJSON actionsObj
+    pure $ SlackInteractivePayload {..}
+
+-- | Which component and it's IDs that triggered an interactive webhook call.
+data SlackActionResponse = SlackActionResponse
+  { sarBlockId :: SlackBlockId
+  , sarActionId :: SlackActionId
+  , sarActionComponent :: SlackActionComponent
+  }
+  deriving stock (Show)
+
+instance FromJSON SlackActionResponse where
+  parseJSON = withObject "SlackActionResponse" $ \obj -> do
+    sarBlockId <- obj .: "block_id"
+    sarActionId <- obj .: "action_id"
+    sarActionComponent <- parseJSON $ Object obj
+    pure $ SlackActionResponse {..}
+
+data SlackInteractiveResponseResponse = SlackInteractiveResponseResponse {unSlackInteractiveResponseResponse :: Bool}
+
+instance FromJSON SlackInteractiveResponseResponse where
+  parseJSON = withObject "SlackInteractiveResponseResponse" $ \obj -> do
+    res <- obj .: "ok"
+    pure $ SlackInteractiveResponseResponse res
+
+-- | Type of message to send in response to an interactive webhook.
+-- See Slack's [Handling user interaction in your Slack apps](https://api.slack.com/interactivity/handling#responses)
+-- for a description of these fieldds.
+data SlackInteractiveResponse
+  = -- | Respond with a new message.
+    SlackInteractiveResponse SlackMessage
+  | -- | Respond with a message that only the interacting user can usee.
+    Ephemeral SlackMessage
+  | -- | Replace the original message.
+    ReplaceOriginal SlackMessage
+  | -- | Delete the original message.
+    DeleteOriginal
+  deriving stock (Show)
+
+instance ToJSON SlackInteractiveResponse where
+  toJSON (SlackInteractiveResponse msg) = object ["blocks" .= msg]
+  toJSON (Ephemeral msg) = object ["blocks" .= msg, "replace_original" .= False, "response_type" .= ("ephemeral" :: Text)]
+  toJSON (ReplaceOriginal msg) = object ["blocks" .= msg, "replace_original" .= True]
+  toJSON DeleteOriginal = object ["delete_original" .= True]
+
+-- | Text to be displayed in a 'SlackButton'.
+-- Up to 75 characters, but may be truncated to 30 characters.
+newtype SlackButtonText = SlackButtonText (NonEmptyText 75)
+  deriving stock (Show)
+  deriving newtype (Eq, FromJSON)
+
+instance Slack SlackButtonText where
+  message (SlackButtonText m) = SlackText [nonEmptyTextToText m]
+
+-- It isn't the end of the world if this gets truncated (slack may truncate it
+-- to about 30 characters anyway) so we have this convenience instance to
+-- use plain strings for button text.
+instance IsString SlackButtonText where
+  fromString s = SlackButtonText . unsafeMkNonEmptyText . cs $ take 75 s
+
+-- | The component in a 'SlackAction'. Do not use directly.
+-- Use the builder functions such as 'button' instead.
+data SlackActionComponent = SlackButton
+  { slackButtonText :: SlackButtonText -- max length 75, may truncate to ~30
+  , slackButtonUrl :: Maybe (NonEmptyText 3000) -- max length 3000
+  , slackButtonValue :: Maybe (NonEmptyText 2000) -- max length 2000
+  , slackButtonStyle :: Maybe SlackStyle
+  , slackButtonConfirm :: Maybe SlackConfirmObject
+  }
+  deriving stock (Eq)
+
+instance FromJSON SlackActionComponent where
+  parseJSON = withObject "SlactActionComponent" $ \obj -> do
+    (slackActionType :: Text) <- obj .: "type"
+    case slackActionType of
+      "button" -> do
+        text <- obj .: "text"
+        slackButtonText <- text .: "text"
+        slackButtonUrl <- obj .:? "url"
+        slackButtonValue <- obj .:? "value"
+        slackButtonStyle <- obj .:? "style"
+        slackButtonConfirm <- obj .:? "confirm"
+        pure $ SlackButton {..}
+      _ -> fail "Unknown SlackActionComponent type, must be one of ['button']"
+
+instance Show SlackActionComponent where
+  show SlackButton {..} = "[button " <> show slackButtonText <> "]"
+
+instance ToJSON SlackAction where
+  toJSON (SlackAction actionId SlackButton {..}) =
+    objectOptional
+      [ "type" .=! ("button" :: Text)
+      , "action_id" .=! actionId
+      , "text" .=! plaintext slackButtonText
+      , "url" .=? slackButtonUrl
+      , "value" .=? slackButtonValue
+      , "style" .=? slackButtonStyle
+      , "confirm" .=? slackButtonConfirm
+      ]
+
+instance FromJSON SlackAction where
+  parseJSON = withObject "SlackAction" $ \obj -> do
+    actionId <- obj .: "action_id"
+    slackActionComponent <- parseJSON $ Object obj
+    pure $ SlackAction actionId slackActionComponent


### PR DESCRIPTION
This is based on #99.

This code is copied (with approval) from the Mercury codebase, with no code modifications except for making `SlackActionId` a `newtype` rather than a sum type.