### PR TITLE
Rich text parsing

### DIFF
--- a/src/Web/Slack/Experimental/Blocks.hs
+++ b/src/Web/Slack/Experimental/Blocks.hs
@@ -26,6 +26,13 @@ module Web.Slack.Experimental.Blocks
     slackMessage,
     SlackBlock (..),
 
+    -- ** Blocks' rich text formatting (receive only!)
+    RichItem(..),
+    RichStyle(..),
+    RichLinkAttrs(..),
+    RichTextSectionItem(..),
+    RichText(..),
+
     -- * Rendered messages
     RenderedSlackMessage (..),
     render,

--- a/src/Web/Slack/Experimental/Blocks.hs
+++ b/src/Web/Slack/Experimental/Blocks.hs
@@ -27,11 +27,11 @@ module Web.Slack.Experimental.Blocks
     SlackBlock (..),
 
     -- ** Blocks' rich text formatting (receive only!)
-    RichItem(..),
-    RichStyle(..),
-    RichLinkAttrs(..),
-    RichTextSectionItem(..),
-    RichText(..),
+    RichItem (..),
+    RichStyle (..),
+    RichLinkAttrs (..),
+    RichTextSectionItem (..),
+    RichText (..),
 
     -- * Rendered messages
     RenderedSlackMessage (..),


### PR DESCRIPTION
Slack ships rich text via the API, but it's not possible to *send* it,
only receive it.

I have a bunch of Golden test cases I will bring into slack-web for
this but they're all via Events, which is something that I need to extricate
from the bot codebase they're in.