### PR TITLE
Mark some fields that are not always there as Maybe

### DIFF
--- a/src/Web/Slack/Conversation.hs
+++ b/src/Web/Slack/Conversation.hs
@@ -55,8 +55,10 @@ import Data.Aeson.Types
 -- slack-web
 
 -- scientific
-import Data.Scientific
+
 -- text
+
+import Data.Scientific
 import Data.Text (Text)
 import Data.Text qualified as T
 import GHC.Generics (Generic)
@@ -117,7 +119,8 @@ data ChannelConversation = ChannelConversation
     -- , channelPendingConnectedTeamIds :: [TeamId]
 
     channelIsPendingExtShared :: Bool
-  , channelIsMember :: Bool
+  -- | Absent from @users.conversations@ response
+  , channelIsMember :: Maybe Bool
   , channelTopic :: Topic
   , channelPurpose :: Purpose
   , channelPreviousNames :: [Text]

--- a/src/Web/Slack/Conversation.hs
+++ b/src/Web/Slack/Conversation.hs
@@ -119,12 +119,13 @@ data ChannelConversation = ChannelConversation
     -- , channelPendingConnectedTeamIds :: [TeamId]
 
     channelIsPendingExtShared :: Bool
-  -- | Absent from @users.conversations@ response
   , channelIsMember :: Maybe Bool
+  -- ^ Absent from @users.conversations@ response
   , channelTopic :: Topic
   , channelPurpose :: Purpose
   , channelPreviousNames :: [Text]
-  , channelNumMembers :: Integer
+  , channelNumMembers :: Maybe Integer
+  -- ^ Absent from @conversations.join@ response
   }
   deriving stock (Eq, Show, Generic)
 

--- a/src/Web/Slack/Conversation.hs
+++ b/src/Web/Slack/Conversation.hs
@@ -38,26 +38,13 @@ module Web.Slack.Conversation
 where
 
 -- FIXME: Web.Slack.Prelude
-
--- aeson
-
--- base
 import Control.Applicative (empty, (<|>))
--- deepseq
 import Control.DeepSeq (NFData)
 import Data.Aeson
 import Data.Aeson.Encoding
 import Data.Aeson.KeyMap qualified as KM
 import Data.Aeson.TH
 import Data.Aeson.Types
--- http-api-data
-
--- slack-web
-
--- scientific
-
--- text
-
 import Data.Scientific
 import Data.Text (Text)
 import Data.Text qualified as T


### PR DESCRIPTION
I implemented these methods in slacklinker (implementations with tests + test-data will be moved here eventually) and found that the Conversation type was inaccurately defined in those cases:

https://api.slack.com/methods/conversations.join
https://api.slack.com/methods/users.conversations