### PR TITLE
Do paged conversation lists; change the pager to be generic over types

### DIFF
--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -105,6 +105,7 @@ library
       Web.Slack.Internal
       Web.Slack.MessageParser
       Web.Slack.Pager
+      Web.Slack.Pager.Types
       Web.Slack.Types
       Web.Slack.User
       Web.Slack.Experimental.Blocks

--- a/src/Web/Slack.hs
+++ b/src/Web/Slack.hs
@@ -19,6 +19,7 @@ module Web.Slack
     authTest,
     chatPostMessage,
     conversationsList,
+    conversationsListAll,
     conversationsHistory,
     conversationsHistoryAll,
     conversationsReplies,
@@ -147,6 +148,20 @@ conversationsList_ ::
   Conversation.ListReq ->
   ClientM (ResponseJSON Conversation.ListRsp)
 
+-- | Returns an action to send a request to get the list of conversations in the
+--   workspace.
+--
+--   To fetch all replies in the conversation, run the returned 'LoadPage' action
+--   repeatedly until it returns an empty list.
+conversationsListAll ::
+  SlackConfig ->
+  -- | The first request to send. _NOTE_: 'Conversation.listReqCursor' is silently ignored.
+  Conversation.ListReq ->
+  -- | An action which returns a new page of messages every time called.
+  --   If there are no pages anymore, it returns an empty list.
+  IO (LoadPage IO Conversation.Conversation)
+conversationsListAll = fetchAllBy . conversationsList
+
 -- |
 --
 -- Retrieve ceonversation history.
@@ -264,7 +279,7 @@ conversationsHistoryAll ::
   -- | An action which returns a new page of messages every time called.
   --   If there are no pages anymore, it returns an empty list.
   IO (LoadPage IO Common.Message)
-conversationsHistoryAll = conversationsHistoryAllBy . conversationsHistory
+conversationsHistoryAll = fetchAllBy . conversationsHistory
 
 -- | Returns an action to send a request to get the replies of a conversation.
 --
@@ -282,7 +297,7 @@ repliesFetchAll ::
   -- | An action which returns a new page of messages every time called.
   --   If there are no pages anymore, it returns an empty list.
   IO (LoadPage IO Common.Message)
-repliesFetchAll = repliesFetchAllBy . conversationsReplies
+repliesFetchAll = fetchAllBy . conversationsReplies
 
 apiTest_
   :<|> authTest_

--- a/src/Web/Slack/Classy.hs
+++ b/src/Web/Slack/Classy.hs
@@ -191,7 +191,7 @@ conversationsHistoryAll ::
   -- | An action which returns a new page of messages every time called.
   --   If there are no pages anymore, it returns an empty list.
   m (LoadPage m Common.Message)
-conversationsHistoryAll = conversationsHistoryAllBy conversationsHistory
+conversationsHistoryAll = fetchAllBy conversationsHistory
 
 -- | Returns an action to send a request to get the replies of a conversation.
 --
@@ -209,7 +209,7 @@ repliesFetchAll ::
   -- | An action which returns a new page of messages every time called.
   --   If there are no pages anymore, it returns an empty list.
   m (LoadPage m Common.Message)
-repliesFetchAll = repliesFetchAllBy conversationsReplies
+repliesFetchAll = fetchAllBy conversationsReplies
 
 liftNonClassy ::
   (MonadReader env m, HasManager env, HasToken env, MonadIO m) =>

--- a/src/Web/Slack/Pager/Types.hs
+++ b/src/Web/Slack/Pager/Types.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Web.Slack.Pager.Types where
+
+import Web.Slack.Prelude
+import Web.Slack.Util
+
+newtype Cursor = Cursor {unCursor :: Text}
+  deriving stock (Eq, Generic, Show)
+  deriving newtype (NFData, Hashable, FromJSON, ToJSON, ToHttpApiData)
+
+newtype ResponseMetadata = ResponseMetadata {responseMetadataNextCursor :: Maybe Cursor}
+  deriving stock (Eq, Show, Generic)
+
+instance NFData ResponseMetadata
+
+$(deriveJSON (jsonOpts "responseMetadata") ''ResponseMetadata)
+
+class PagedRequest a where
+  setCursor :: Maybe Cursor -> a -> a
+
+class PagedResponse a where
+  type ResponseObject a
+  getResponseMetadata :: a -> Maybe ResponseMetadata
+  getResponseData :: a -> [ResponseObject a]

--- a/src/Web/Slack/Prelude.hs
+++ b/src/Web/Slack/Prelude.hs
@@ -3,6 +3,7 @@ module Web.Slack.Prelude
     module Data.Aeson,
     module Data.Aeson.TH,
     cs,
+    ToHttpApiData,
   )
 where
 
@@ -10,3 +11,4 @@ import ClassyPrelude hiding (link)
 import Data.Aeson (FromJSON (..), ToJSON (..), object, withObject, (.:), (.:?), (.=))
 import Data.Aeson.TH (deriveJSON)
 import Data.String.Conversions (cs)
+import Web.HttpApiData (ToHttpApiData)

--- a/src/Web/Slack/Types.hs
+++ b/src/Web/Slack/Types.hs
@@ -18,14 +18,6 @@ module Web.Slack.Types
   )
 where
 
--- aeson
-
--- http-api-data
-
--- text
-
--- time
-
 import Control.Monad (MonadFail (..))
 import Data.Aeson
 import Data.Text qualified as T
@@ -33,6 +25,7 @@ import Data.Text.Read (rational)
 import Data.Time.Clock
 import Data.Time.Clock.POSIX
 import Web.HttpApiData
+import Web.Slack.Pager.Types
 import Web.Slack.Prelude
 
 -- Ord to allow it to be a key of a Map
@@ -55,10 +48,6 @@ newtype ConversationId = ConversationId {unConversationId :: Text}
 -- Ord to allow it to be a key of a Map
 newtype TeamId = TeamId {unTeamId :: Text}
   deriving stock (Eq, Ord, Generic, Show)
-  deriving newtype (NFData, Hashable, FromJSON, ToJSON, ToHttpApiData)
-
-newtype Cursor = Cursor {unCursor :: Text}
-  deriving stock (Eq, Generic, Show)
   deriving newtype (NFData, Hashable, FromJSON, ToJSON, ToHttpApiData)
 
 -- | Message text in the format returned by Slack,

--- a/tests/Web/Slack/PagerSpec.hs
+++ b/tests/Web/Slack/PagerSpec.hs
@@ -6,8 +6,7 @@ import Data.Time.Clock (addUTCTime, nominalDay)
 import Test.Pull.Fake.IO (FakeStream, newFakeStream, pull)
 import TestImport
 import Web.Slack.Common
-  ( Cursor (..),
-    Message (..),
+  ( Message (..),
     MessageType (..),
     SlackMessageText (..),
     mkSlackTimestamp,
@@ -17,7 +16,6 @@ import Web.Slack.Conversation
     HistoryReq (..),
     HistoryRsp (..),
     RepliesReq (..),
-    ResponseMetadata (..),
     mkHistoryReq,
     mkRepliesReq,
   )
@@ -69,7 +67,7 @@ spec = do
               , historyReqOldest = Just oldest
               , historyReqInclusive = False
               }
-      loadPage <- conversationsHistoryAllBy (stubbedSendRequest responsesToReturn) initialRequest
+      loadPage <- fetchAllBy (stubbedSendRequest responsesToReturn) initialRequest
       let actual = unfoldPageM $ either throwIO return =<< loadPage
       expected <- fmap (map historyRspMessages) . either throwIO return $ sequenceA allResponses
       actual `shouldReturn` expected
@@ -84,7 +82,7 @@ spec = do
               , repliesReqOldest = Just oldest
               , repliesReqInclusive = False
               }
-      loadPage <- repliesFetchAllBy (stubbedSendRequest responsesToReturn) initialRequest
+      loadPage <- fetchAllBy (stubbedSendRequest responsesToReturn) initialRequest
       let actual = unfoldPageM $ either throwIO return =<< loadPage
       expected <- fmap (map historyRspMessages) . either throwIO return $ sequenceA allResponses
       actual `shouldReturn` expected


### PR DESCRIPTION
I need to be able to do paged conversation lists for slacklinker, since I expect I will have a lot of conversations to go through.

This meant that the existing pager stuff that was hardcoded to one response type needed to fixed. So I fixed it by deleting a bunch of duplicated code by making it generic.