### PR TITLE
Fix the case where there are no blocks, just attachments

### DIFF
--- a/src/Web/Slack/Experimental/Events/Types.hs
+++ b/src/Web/Slack/Experimental/Events/Types.hs
@@ -23,7 +23,7 @@ $(deriveJSON snakeCaseOptions ''ChannelType)
 
 -- | <https://api.slack.com/events/message>
 data MessageEvent = MessageEvent
-  { blocks :: Maybe (NonEmpty SlackBlock)
+  { blocks :: Maybe [SlackBlock]
   , channel :: ConversationId
   , text :: Text
   , channelType :: ChannelType

--- a/src/Web/Slack/Experimental/Events/Types.hs
+++ b/src/Web/Slack/Experimental/Events/Types.hs
@@ -23,7 +23,7 @@ $(deriveJSON snakeCaseOptions ''ChannelType)
 
 -- | <https://api.slack.com/events/message>
 data MessageEvent = MessageEvent
-  { blocks :: [SlackBlock]
+  { blocks :: Maybe (NonEmpty SlackBlock)
   , channel :: ConversationId
   , text :: Text
   , channelType :: ChannelType

--- a/tests/Web/Slack/Experimental/Events/TypesSpec.hs
+++ b/tests/Web/Slack/Experimental/Events/TypesSpec.hs
@@ -19,4 +19,5 @@ spec = describe "Types for Slack events" do
         , "messageIm"
         , "slackbotIm"
         , "channel_left"
+        , "share_without_message"
         ]

--- a/tests/golden/SlackWebhookEvent/botMessage.golden
+++ b/tests/golden/SlackWebhookEvent/botMessage.golden
@@ -10,8 +10,8 @@ EventEventCallback
             }
         , event = EventMessage
             ( MessageEvent
-                { blocks =
-                    [ RichText
+                { blocks = Just
+                    ( RichText
                         { blockId = Just
                             ( NonEmptyText "FVI" )
                         , elements =
@@ -24,8 +24,8 @@ EventEventCallback
                                     )
                                 ]
                             ]
-                        }
-                    ]
+                        } :| []
+                    )
                 , channel = ConversationId
                     { unConversationId = "C043YJGBY49" }
                 , text = "TEST"

--- a/tests/golden/SlackWebhookEvent/botMessage.golden
+++ b/tests/golden/SlackWebhookEvent/botMessage.golden
@@ -11,7 +11,7 @@ EventEventCallback
         , event = EventMessage
             ( MessageEvent
                 { blocks = Just
-                    ( RichText
+                    [ RichText
                         { blockId = Just
                             ( NonEmptyText "FVI" )
                         , elements =
@@ -24,8 +24,8 @@ EventEventCallback
                                     )
                                 ]
                             ]
-                        } :| []
-                    )
+                        }
+                    ]
                 , channel = ConversationId
                     { unConversationId = "C043YJGBY49" }
                 , text = "TEST"

--- a/tests/golden/SlackWebhookEvent/link.golden
+++ b/tests/golden/SlackWebhookEvent/link.golden
@@ -11,7 +11,7 @@ EventEventCallback
         , event = EventMessage
             ( MessageEvent
                 { blocks = Just
-                    ( RichText
+                    [ RichText
                         { blockId = Just
                             ( NonEmptyText "MEdM" )
                         , elements =
@@ -28,8 +28,8 @@ EventEventCallback
                                     )
                                 ]
                             ]
-                        } :| []
-                    )
+                        }
+                    ]
                 , channel = ConversationId
                     { unConversationId = "C043YJGBY49" }
                 , text = "<https://jadeapptesting.slack.com/archives/C043YJGBY49/p1663961604007869>"

--- a/tests/golden/SlackWebhookEvent/link.golden
+++ b/tests/golden/SlackWebhookEvent/link.golden
@@ -10,8 +10,8 @@ EventEventCallback
             }
         , event = EventMessage
             ( MessageEvent
-                { blocks =
-                    [ RichText
+                { blocks = Just
+                    ( RichText
                         { blockId = Just
                             ( NonEmptyText "MEdM" )
                         , elements =
@@ -28,8 +28,8 @@ EventEventCallback
                                     )
                                 ]
                             ]
-                        }
-                    ]
+                        } :| []
+                    )
                 , channel = ConversationId
                     { unConversationId = "C043YJGBY49" }
                 , text = "<https://jadeapptesting.slack.com/archives/C043YJGBY49/p1663961604007869>"

--- a/tests/golden/SlackWebhookEvent/messageExample.golden
+++ b/tests/golden/SlackWebhookEvent/messageExample.golden
@@ -11,7 +11,7 @@ EventEventCallback
         , event = EventMessage
             ( MessageEvent
                 { blocks = Just
-                    ( RichText
+                    [ RichText
                         { blockId = Just
                             ( NonEmptyText "u6n" )
                         , elements =
@@ -24,8 +24,8 @@ EventEventCallback
                                     )
                                 ]
                             ]
-                        } :| []
-                    )
+                        }
+                    ]
                 , channel = ConversationId
                     { unConversationId = "C043YJGBY49" }
                 , text = "dgsfklsdgf"

--- a/tests/golden/SlackWebhookEvent/messageExample.golden
+++ b/tests/golden/SlackWebhookEvent/messageExample.golden
@@ -10,8 +10,8 @@ EventEventCallback
             }
         , event = EventMessage
             ( MessageEvent
-                { blocks =
-                    [ RichText
+                { blocks = Just
+                    ( RichText
                         { blockId = Just
                             ( NonEmptyText "u6n" )
                         , elements =
@@ -24,8 +24,8 @@ EventEventCallback
                                     )
                                 ]
                             ]
-                        }
-                    ]
+                        } :| []
+                    )
                 , channel = ConversationId
                     { unConversationId = "C043YJGBY49" }
                 , text = "dgsfklsdgf"

--- a/tests/golden/SlackWebhookEvent/messageIm.golden
+++ b/tests/golden/SlackWebhookEvent/messageIm.golden
@@ -10,8 +10,8 @@ EventEventCallback
             }
         , event = EventMessage
             ( MessageEvent
-                { blocks =
-                    [ RichText
+                { blocks = Just
+                    ( RichText
                         { blockId = Just
                             ( NonEmptyText "LSo" )
                         , elements =
@@ -24,8 +24,8 @@ EventEventCallback
                                     )
                                 ]
                             ]
-                        }
-                    ]
+                        } :| []
+                    )
                 , channel = ConversationId
                     { unConversationId = "D0442US94JD" }
                 , text = "test"

--- a/tests/golden/SlackWebhookEvent/messageIm.golden
+++ b/tests/golden/SlackWebhookEvent/messageIm.golden
@@ -11,7 +11,7 @@ EventEventCallback
         , event = EventMessage
             ( MessageEvent
                 { blocks = Just
-                    ( RichText
+                    [ RichText
                         { blockId = Just
                             ( NonEmptyText "LSo" )
                         , elements =
@@ -24,8 +24,8 @@ EventEventCallback
                                     )
                                 ]
                             ]
-                        } :| []
-                    )
+                        }
+                    ]
                 , channel = ConversationId
                     { unConversationId = "D0442US94JD" }
                 , text = "test"

--- a/tests/golden/SlackWebhookEvent/share_without_message.golden
+++ b/tests/golden/SlackWebhookEvent/share_without_message.golden
@@ -1,0 +1,27 @@
+EventEventCallback
+    ( EventCallback
+        { eventId = EventId
+            { unEventId = "Ev04BEN3QMSM" }
+        , teamId = TeamId
+            { unTeamId = "T043DB835ML" }
+        , eventTime = MkSystemTime
+            { systemSeconds = 1668537593
+            , systemNanoseconds = 0
+            }
+        , event = EventMessage
+            ( MessageEvent
+                { blocks = Nothing
+                , channel = ConversationId
+                    { unConversationId = "C043YJGBY49" }
+                , text = ""
+                , channelType = Channel
+                , user = UserId
+                    { unUserId = "U043H11ES4V" }
+                , ts = "1668537593.598469"
+                , threadTs = Nothing
+                , appId = Nothing
+                , botId = Nothing
+                }
+            )
+        }
+    )

--- a/tests/golden/SlackWebhookEvent/share_without_message.json
+++ b/tests/golden/SlackWebhookEvent/share_without_message.json
@@ -1,0 +1,78 @@
+{
+  "token": "aaaa",
+  "team_id": "T043DB835ML",
+  "api_app_id": "A0442TUPHGR",
+  "event": {
+    "type": "message",
+    "text": "",
+    "user": "U043H11ES4V",
+    "ts": "1668537593.598469",
+    "team": "T043DB835ML",
+    "attachments": [
+      {
+        "from_url": "https://jadeapptesting.slack.com/archives/C043KSKGJUB/p1665615886364019",
+        "ts": "1665615886.364019",
+        "author_id": "U043H11ES4V",
+        "channel_id": "C043KSKGJUB",
+        "channel_team": "T043DB835ML",
+        "channel_name": "testing-slack-app",
+        "is_msg_unfurl": true,
+        "message_blocks": [
+          {
+            "team": "T043DB835ML",
+            "channel": "C043KSKGJUB",
+            "ts": "1665615886.364019",
+            "message": {
+              "blocks": [
+                {
+                  "type": "rich_text",
+                  "block_id": "TNHa4",
+                  "elements": [
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "text",
+                          "text": "blahblahblahblahblah"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "color": "D0D0D0",
+        "is_share": true,
+        "fallback": "[October 12th, 2022 4:04 PM] jadel: blahblahblahblahblah",
+        "text": "blahblahblahblahblah",
+        "author_name": "jadel",
+        "author_link": "https://jadeapptesting.slack.com/team/U043H11ES4V",
+        "author_icon": "https://secure.gravatar.com/avatar/dcd5bc53dcfaca62ddc3f5726d07ba13.jpg?s=48&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0019-48.png",
+        "author_subname": "jadel",
+        "mrkdwn_in": [
+          "text"
+        ],
+        "footer": "Posted in #testing-slack-app"
+      }
+    ],
+    "channel": "C043YJGBY49",
+    "event_ts": "1668537593.598469",
+    "channel_type": "channel"
+  },
+  "type": "event_callback",
+  "event_id": "Ev04BEN3QMSM",
+  "event_time": 1668537593,
+  "authorizations": [
+    {
+      "enterprise_id": null,
+      "team_id": "T043DB835ML",
+      "user_id": "U0442US8QGH",
+      "is_bot": true,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": "aaaa"
+}

--- a/tests/golden/SlackWebhookEvent/slackbotIm.golden
+++ b/tests/golden/SlackWebhookEvent/slackbotIm.golden
@@ -10,8 +10,8 @@ EventEventCallback
             }
         , event = EventMessage
             ( MessageEvent
-                { blocks =
-                    [ RichText
+                { blocks = Just
+                    ( RichText
                         { blockId = Just
                             ( NonEmptyText "ZRe" )
                         , elements =
@@ -33,8 +33,8 @@ EventEventCallback
                                     )
                                 ]
                             ]
-                        }
-                    ]
+                        } :| []
+                    )
                 , channel = ConversationId
                     { unConversationId = "D043HMJ0WDU" }
                 , text = "You have been removed from #testing-slack-app by <@U043H11ES4V>"

--- a/tests/golden/SlackWebhookEvent/slackbotIm.golden
+++ b/tests/golden/SlackWebhookEvent/slackbotIm.golden
@@ -11,7 +11,7 @@ EventEventCallback
         , event = EventMessage
             ( MessageEvent
                 { blocks = Just
-                    ( RichText
+                    [ RichText
                         { blockId = Just
                             ( NonEmptyText "ZRe" )
                         , elements =
@@ -33,8 +33,8 @@ EventEventCallback
                                     )
                                 ]
                             ]
-                        } :| []
-                    )
+                        }
+                    ]
                 , channel = ConversationId
                     { unConversationId = "D043HMJ0WDU" }
                 , text = "You have been removed from #testing-slack-app by <@U043H11ES4V>"


### PR DESCRIPTION
This code slightly bothers me: it's fragile to Slack returning [] for the blocks rather than omitting the field (which I don't know if I've seen, to be fair), but I'm not sure how I can do it more reasonably, since the alternative is to use some crime similar to "NullableNonEmptyText" or write instances by hand, neither of which I want to do.

This was found by hitting the share button and sharing a message to a channel with no note.