### PR TITLE
Kill NonEmpty in users.conversations

### DIFF
--- a/src/Web/Slack/Conversation.hs
+++ b/src/Web/Slack/Conversation.hs
@@ -91,7 +91,7 @@ data ChannelConversation = ChannelConversation
     channelCreator :: UserId
   , channelIsExtShared :: Bool
   , channelIsOrgShared :: Bool
-  , channelSharedTeamIds :: Maybe (NonEmpty TeamId)
+  , channelSharedTeamIds :: Maybe [TeamId]
   -- ^ Ironically this has been observed to be absent on real shared-channel
   -- responses.
   , -- FIXME:

--- a/tests/golden/UsersConversationsResponse/im_and_channels.golden
+++ b/tests/golden/UsersConversationsResponse/im_and_channels.golden
@@ -16,9 +16,9 @@ UsersConversationsResponse
                 , channelIsExtShared = False
                 , channelIsOrgShared = False
                 , channelSharedTeamIds = Just
-                    ( TeamId
-                        { unTeamId = "T043DB835ML" } :| []
-                    )
+                    [ TeamId
+                        { unTeamId = "T043DB835ML" }
+                    ]
                 , channelIsPendingExtShared = False
                 , channelIsMember = Nothing
                 , channelTopic = Topic
@@ -51,9 +51,9 @@ UsersConversationsResponse
                 , channelIsExtShared = False
                 , channelIsOrgShared = False
                 , channelSharedTeamIds = Just
-                    ( TeamId
-                        { unTeamId = "T043DB835ML" } :| []
-                    )
+                    [ TeamId
+                        { unTeamId = "T043DB835ML" }
+                    ]
                 , channelIsPendingExtShared = False
                 , channelIsMember = Nothing
                 , channelTopic = Topic


### PR DESCRIPTION
I am worried about fragility with respect to Slack API changes, so I want to relax this before releasing the next Hackage version.