### PR TITLE
Steal PR template from Persistent

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+Before submitting your PR, check that you've:
+
+- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
+- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
+
+After submitting your PR:
+
+- [ ] Update the Changelog.md file with a link to your PR
+- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
+- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)
+
+<!---Thanks so much for contributing! :)
+
+_If these checkboxes don't apply to your PR, you can delete them_-->


### PR DESCRIPTION
We should have one of these, if only to encourage more frequent releases.