### PR TITLE
Parse Slack email objects without exploding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.6.1.0 (2022-12-16)
+
+* [#124](https://github.com/MercuryTechnologies/slack-web/pull/124)
+  Parse [Slack incoming emails](https://slack.com/help/articles/206819278-Send-emails-to-Slack)
+  without throwing an error.
+
 # 1.6.0.0 (2022-12-14)
 
 ## Breaking changes

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -8,8 +8,8 @@ license: MIT
 license-file: LICENSE.md
 
 copyright: 2017 Juan Pedro Villa Isaza, 2022 Mercury Technologies, Inc
-author: Juan Pedro Villa Isaza <jpvillaisaza@gmail.com>, Jade Lovelace <jadel@mercury.com>, Dennis Hennen <dennis@mercury.com>
-maintainer: Jade Lovelace <jadel@mercury.com>
+author: Juan Pedro Villa Isaza <jpvillaisaza@gmail.com>, Jade Lovelace <software at lfcode dot ca>, Dennis Hennen <dennis@mercury.com>
+maintainer: Jade Lovelace <software at lfcode dot ca>
 
 homepage: https://github.com/MercuryTechnologies/slack-web
 bug-reports: https://github.com/MercuryTechnologies/slack-web/issues

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -187,6 +187,7 @@ test-suite tests
       Web.Slack.Experimental.Events.TypesSpec
       Web.Slack.Experimental.BlocksSpec
       TestImport
+      TestImport.Aeson
   build-tool-depends:
     hspec-discover:hspec-discover >=2.6.0 && <2.11
   build-depends:
@@ -197,6 +198,7 @@ test-suite tests
     , bytestring
     , classy-prelude
     , fakepull
+    , generic-arbitrary
     , hspec
     , hspec-core
     , hspec-golden

--- a/src/Web/Slack/Files/Types.hs
+++ b/src/Web/Slack/Files/Types.hs
@@ -18,10 +18,42 @@ newtype FileId = FileId {unFileId :: Text}
   deriving stock (Show, Eq)
   deriving newtype (FromJSON, ToJSON)
 
-data FileMode = Hosted | External | Snippet | Post | FileAccess
-  deriving stock (Show, Eq)
+data FileMode
+  = Hosted
+  | External
+  | Snippet
+  | Post
+  | FileAccess
+  | -- | <https://slack.com/help/articles/206819278-Send-emails-to-Slack>
+    --
+    -- @since 1.6.1.0
+    Email
+  | -- | Other file modes.
+    --
+    --   @since 1.6.1.0
+    Other Text
+  deriving stock (Show, Eq, Generic)
 
-$(deriveJSON snakeCaseOptions ''FileMode)
+instance FromJSON FileMode where
+  parseJSON = A.withText "FileMode" \case
+    "hosted" -> pure Hosted
+    "external" -> pure External
+    "snippet" -> pure Snippet
+    "post" -> pure Post
+    "file_access" -> pure FileAccess
+    "email" -> pure Email
+    other -> pure . Other $ other
+
+instance ToJSON FileMode where
+  toJSON =
+    A.String . \case
+      Hosted -> "hosted"
+      External -> "external"
+      Snippet -> "snippet"
+      Post -> "post"
+      FileAccess -> "file_access"
+      Email -> "email"
+      Other s -> s
 
 -- | <https://api.slack.com/types/file>
 data FileObjectVisible = FileObjectVisible

--- a/tests/TestImport.hs
+++ b/tests/TestImport.hs
@@ -2,10 +2,12 @@ module TestImport
   ( fromJust,
     module Control.Monad.Fail,
     module Test.Hspec,
+    module Test.Hspec.QuickCheck,
     module ClassyPrelude,
     module Data.Aeson,
     module Data.Aeson.TH,
     cs,
+    module Test.QuickCheck,
   )
 where
 
@@ -16,3 +18,6 @@ import Data.Aeson.TH (deriveJSON)
 import Data.Maybe (fromJust)
 import Data.String.Conversions (cs)
 import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.QuickCheck
+import Test.QuickCheck.Instances ()

--- a/tests/TestImport/Aeson.hs
+++ b/tests/TestImport/Aeson.hs
@@ -1,0 +1,14 @@
+module TestImport.Aeson (aesonRoundtrips) where
+
+import Data.Aeson.Types qualified as A
+import TestImport
+
+aesonRoundtrips :: forall a. (FromJSON a, ToJSON a, Eq a) => a -> Bool
+aesonRoundtrips a =
+  let encoded = toJSON a
+      parsed = A.parse (parseJSON @a) encoded
+      roundTwo = fmap (toJSON @a) parsed
+   in -- The encoding is the same
+      A.Success encoded == roundTwo
+        -- AND the object itself is the same
+        && A.Success a == parsed

--- a/tests/Web/Slack/Experimental/Events/TypesSpec.hs
+++ b/tests/Web/Slack/Experimental/Events/TypesSpec.hs
@@ -23,4 +23,6 @@ spec = describe "Types for Slack events" do
         , "slackbotIm"
         , "channel_left"
         , "share_without_message"
+        , -- https://slack.com/help/articles/206819278-Send-emails-to-Slack
+          "email_message"
         ]

--- a/tests/Web/Slack/Files/TypesSpec.hs
+++ b/tests/Web/Slack/Files/TypesSpec.hs
@@ -1,12 +1,21 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+-- GHC told me to set it, and it compiles now 🤷
+{-# OPTIONS_GHC -fconstraint-solver-iterations=10 #-}
+
 module Web.Slack.Files.TypesSpec (spec) where
 
 import JSONGolden
+import Test.QuickCheck.Arbitrary.Generic (GenericArbitrary (..))
 import TestImport
+import TestImport.Aeson
 import Web.Slack.Files.Types
+
+deriving via GenericArbitrary FileMode instance Arbitrary FileMode
 
 spec :: Spec
 spec = describe "Types for Slack files" do
   describe "FileObject" do
+    prop "FileMode roundtrips" $ aesonRoundtrips @FileMode
     describe "FromJSON" do
       mapM_
         (oneGoldenTestDecode @FileObject)

--- a/tests/golden/SlackWebhookEvent/email_message.golden
+++ b/tests/golden/SlackWebhookEvent/email_message.golden
@@ -1,0 +1,43 @@
+EventEventCallback
+    ( EventCallback
+        { eventId = EventId
+            { unEventId = "Ev0123467899" }
+        , teamId = TeamId
+            { unTeamId = "T012346789" }
+        , eventTime = MkSystemTime
+            { systemSeconds = 1671217113
+            , systemNanoseconds = 0
+            }
+        , event = EventMessage
+            ( MessageEvent
+                { blocks = Nothing
+                , channel = ConversationId
+                    { unConversationId = "C012346789" }
+                , text = ""
+                , channelType = Channel
+                , files = Just
+                    [ VisibleFileObject
+                        ( FileObjectVisible
+                            { id = FileId
+                                { unFileId = "F0123468789" }
+                            , created = 2022-12-16 18:58:33 UTC
+                            , name = "meow"
+                            , title = "meow"
+                            , mimetype = "text/html"
+                            , urlPrivate = "https://example.com"
+                            , isExternal = False
+                            , size = 6212
+                            , mode = Email
+                            }
+                        )
+                    ]
+                , user = UserId
+                    { unUserId = "USLACKBOT" }
+                , ts = "1671217113.292829"
+                , threadTs = Nothing
+                , appId = Nothing
+                , botId = Just "B012346789"
+                }
+            )
+        }
+    )

--- a/tests/golden/SlackWebhookEvent/email_message.json
+++ b/tests/golden/SlackWebhookEvent/email_message.json
@@ -1,0 +1,91 @@
+{
+  "token": "aaaa",
+  "team_id": "T012346789",
+  "api_app_id": "A012346789",
+  "event": {
+    "type": "message",
+    "text": "",
+    "files": [
+      {
+        "id": "F0123468789",
+        "created": 1671217113,
+        "timestamp": 1671217110,
+        "name": "meow",
+        "title": "meow",
+        "mimetype": "text/html",
+        "filetype": "email",
+        "pretty_type": "Email",
+        "user": "USLACKBOT",
+        "user_team": "T012346789",
+        "editable": true,
+        "size": 6212,
+        "mode": "email",
+        "is_external": false,
+        "external_type": "",
+        "is_public": true,
+        "public_url_shared": false,
+        "display_as_bot": true,
+        "username": "Email",
+        "url_private": "https://example.com",
+        "url_private_download": "https://example.com",
+        "permalink": "https://example.com",
+        "permalink_public": "https://example.com",
+        "subject": "meow",
+        "to": [
+          {
+            "address": "",
+            "name": "Email",
+            "original": "Email <>"
+          }
+        ],
+        "from": [
+          {
+            "address": "addr@example.com",
+            "name": "meow",
+            "original": "meow <addr@example.com>"
+          }
+        ],
+        "cc": [],
+        "attachments": [],
+        "original_attachment_count": 0,
+        "plain_text": "meow",
+        "preview": "meow",
+        "preview_plain_text": "meow",
+        "headers": {
+          "date": "Fri, 16 Dec 2022 18:58:30 +0000",
+          "in_reply_to": null,
+          "reply_to": null,
+          "message_id": "<meow@example.com>"
+        },
+        "has_more": false,
+        "sent_to_self": false,
+        "bot_id": "B012346789",
+        "has_rich_preview": false,
+        "file_access": "visible"
+      }
+    ],
+    "upload": true,
+    "user": "USLACKBOT",
+    "display_as_bot": true,
+    "bot_id": "B012346789",
+    "ts": "1671217113.292829",
+    "channel": "C012346789",
+    "subtype": "file_share",
+    "event_ts": "1671217113.292829",
+    "channel_type": "channel"
+  },
+  "type": "event_callback",
+  "event_id": "Ev0123467899",
+  "event_time": 1671217113,
+  "authorizations": [
+    {
+      "enterprise_id": null,
+      "team_id": "T012346789",
+      "user_id": "U012346789",
+      "is_bot": true,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": "aaaa"
+}


### PR DESCRIPTION
We really should have expected that Slack didn't document all the types of file. 🤦‍♀️

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
