### PR TITLE
Add helper for the divider block type

### DIFF
--- a/.github/workflows/nix-checks.yaml
+++ b/.github/workflows/nix-checks.yaml
@@ -10,9 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Nix
-        uses: cachix/install-nix-action@v19
+        uses: cachix/install-nix-action@v17
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config: |
             extra-experimental-features = nix-command flakes
       - uses: cachix/cachix-action@v10

--- a/.github/workflows/nix-checks.yaml
+++ b/.github/workflows/nix-checks.yaml
@@ -10,8 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Nix
-        uses: cachix/install-nix-action@v17
+        uses: cachix/install-nix-action@v19
         with:
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
           extra_nix_config: |
             extra-experimental-features = nix-command flakes
       - uses: cachix/cachix-action@v10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.6.2.0 (2023-10-24)
+
+* [#127](https://github.com/MercuryTechnologies/slack-web/pull/127)
+  Add helper for the divider block type.
+
 # 1.6.1.0 (2022-12-16)
 
 * [#124](https://github.com/MercuryTechnologies/slack-web/pull/124)

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name: slack-web
-version: 1.6.1.0
+version: 1.6.2.0
 
 build-type: Simple
 

--- a/src/Web/Slack/Experimental/Blocks/Types.hs
+++ b/src/Web/Slack/Experimental/Blocks/Types.hs
@@ -545,6 +545,11 @@ button actionId buttonText ButtonSettings {..} =
       , slackButtonConfirm = unOptionalSetting buttonConfirm
       }
 
+-- | A divider block.
+-- https://api.slack.com/reference/block-kit/blocks#divider
+divider :: SlackMessage
+divider = SlackMessage [SlackBlockDivider]
+
 -- | Settings for [confirmation dialog objects](https://api.slack.com/reference/block-kit/composition-objects#confirm).
 data ConfirmSettings = ConfirmSettings
   { confirmTitle :: Text

--- a/src/Web/Slack/Experimental/Blocks/Types.hs
+++ b/src/Web/Slack/Experimental/Blocks/Types.hs
@@ -547,6 +547,8 @@ button actionId buttonText ButtonSettings {..} =
 
 -- | A divider block.
 -- https://api.slack.com/reference/block-kit/blocks#divider
+--
+-- @since 1.6.2.0
 divider :: SlackMessage
 divider = SlackMessage [SlackBlockDivider]
 


### PR DESCRIPTION
This adds a helper for the divider block type, making it easier to insert dividers into a `SlackMessage`. 

Before submitting your PR, check that you've:

- [X] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [X] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
