### PR TITLE
Fix failing check_fourmolu job

### DIFF
--- a/.github/workflows/nix-checks.yaml
+++ b/.github/workflows/nix-checks.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Nix
-        uses: cachix/install-nix-action@v17
+        uses: cachix/install-nix-action@v20
         with:
           extra_nix_config: |
             extra-experimental-features = nix-command flakes


### PR DESCRIPTION
CI is failing [here](https://github.com/MercuryTechnologies/slack-web/actions/runs/6631613835/job/18015495560). This is fixed in version 20 of cachix/install-nix-action. See https://github.com/cachix/install-nix-action/issues/161
