### PR TITLE
support message attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.0.3 (2024-08-30)
+* [#133](https://github.com/MercuryTechnologies/slack-web/pull/133)
+  Adds attachment support for message event subscriptions.
+
 # 2.0.0.2 (2024-08-29)
 * [#132](https://github.com/MercuryTechnologies/slack-web/pull/132)
   Add support for bot_message event subtype.

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name: slack-web
-version: 2.0.0.2
+version: 2.0.0.3
 
 build-type: Simple
 

--- a/src/Web/Slack/Experimental/Events/Types.hs
+++ b/src/Web/Slack/Experimental/Events/Types.hs
@@ -22,6 +22,73 @@ data ChannelType = Channel | Group | Im
 
 $(deriveJSON snakeCaseOptions ''ChannelType)
 
+-- | <https://api.slack.com/events/message/message_attachment>
+-- Ported from https://github.com/slackapi/node-slack-sdk/blob/fc87d51/packages/types/src/message-attachments.ts
+--
+-- @since 2.0.0.3
+data AttachmentField = AttachmentField
+  { title :: Text
+  , value :: Text
+  , short :: Maybe Bool
+  }
+  deriving stock (Show)
+
+$(deriveFromJSON snakeCaseOptions ''AttachmentField)
+
+-- | @since 2.0.0.3
+data AttachmentMessageBlockMessage = AttachmentMessageBlockMessage
+  { blocks :: [SlackBlock]
+  }
+  deriving stock (Show)
+
+$(deriveFromJSON snakeCaseOptions ''AttachmentMessageBlockMessage)
+
+-- | @since 2.0.0.3
+data AttachmentMessageBlock = AttachmentMessageBlock
+  { team :: TeamId
+  , channel :: ConversationId
+  , ts :: Text
+  , message :: AttachmentMessageBlockMessage
+  }
+  deriving stock (Show)
+
+$(deriveFromJSON snakeCaseOptions ''AttachmentMessageBlock)
+
+-- | <https://api.slack.com/events/message/message_attachment>
+-- Ported from https://github.com/slackapi/node-slack-sdk/blob/fc87d51/packages/types/src/message-attachments.ts
+--
+-- @since 2.0.0.3
+data MessageAttachment = MessageAttachment
+  { fallback :: Maybe Text
+  , color :: Maybe Text
+  , pretext :: Maybe Text
+  , authorName :: Maybe Text
+  , authorLink :: Maybe Text
+  , authorIcon :: Maybe Text
+  , title :: Maybe Text
+  , titleLink :: Maybe Text
+  , text :: Maybe Text
+  , fields :: Maybe [AttachmentField]
+  , imageUrl :: Maybe Text
+  , thumbUrl :: Maybe Text
+  , footer :: Maybe Text
+  , footerIcon :: Maybe Text
+  , ts :: Maybe Text
+  , -- the following are undocumented
+    isMsgUnfurl :: Maybe Bool
+  , messageBlocks :: Maybe [AttachmentMessageBlock]
+  -- ^ unfurled message blocks
+  , authorId :: Maybe UserId
+  , channelId :: Maybe ConversationId
+  , channelTeam :: Maybe TeamId
+  , isAppUnfurl :: Maybe Bool
+  , appUnfurlUrl :: Maybe Text
+  , fromUrl :: Maybe Text
+  }
+  deriving stock (Show)
+
+$(deriveFromJSON snakeCaseOptions ''MessageAttachment)
+
 -- | <https://api.slack.com/events/message>
 -- and
 -- <https://api.slack.com/events/message/file_share>
@@ -48,6 +115,9 @@ data MessageEvent = MessageEvent
   --   See @botMessage.json@ golden parser test.
   , botId :: Maybe Text
   -- ^ Present if it's sent by a bot user
+  , attachments :: Maybe [MessageAttachment]
+  -- ^ @since 2.0.0.3
+  -- Present if the message has attachments
   }
   deriving stock (Show)
 
@@ -71,6 +141,9 @@ data BotMessageEvent = BotMessageEvent
   -- ^ Some (or all) bots also have an App ID
   , botId :: Text
   -- ^ Always present for bot_message subtype
+  , attachments :: Maybe [MessageAttachment]
+  -- ^ @since 2.0.0.3
+  -- Present if the message has attachments
   }
   deriving stock (Show)
 

--- a/tests/Web/Slack/Experimental/Events/TypesSpec.hs
+++ b/tests/Web/Slack/Experimental/Events/TypesSpec.hs
@@ -23,8 +23,10 @@ spec = describe "Types for Slack events" do
         , "slackbotIm"
         , "channel_left"
         , "share_without_message"
+        , "share_with_message"
         , "circleci"
         , -- https://slack.com/help/articles/206819278-Send-emails-to-Slack
           "email_message"
         , "message_subtype_bot_message"
+        , "forwarded_message"
         ]

--- a/tests/golden/SlackWebhookEvent/botMessage.golden
+++ b/tests/golden/SlackWebhookEvent/botMessage.golden
@@ -37,6 +37,7 @@ EventEventCallback
                 , threadTs = Just "1664216109.798919"
                 , appId = Just "A0442TUPHGR"
                 , botId = Just "B0439P161B9"
+                , attachments = Nothing
                 }
             )
         }

--- a/tests/golden/SlackWebhookEvent/circleci.golden
+++ b/tests/golden/SlackWebhookEvent/circleci.golden
@@ -50,6 +50,7 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Just "A56789123"
                 , botId = Just "B01234687"
+                , attachments = Nothing
                 }
             )
         }

--- a/tests/golden/SlackWebhookEvent/email_message.golden
+++ b/tests/golden/SlackWebhookEvent/email_message.golden
@@ -37,6 +37,7 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Nothing
                 , botId = Just "B012346789"
+                , attachments = Nothing
                 }
             )
         }

--- a/tests/golden/SlackWebhookEvent/forwarded_message.golden
+++ b/tests/golden/SlackWebhookEvent/forwarded_message.golden
@@ -1,60 +1,60 @@
 EventEventCallback
     ( EventCallback
         { eventId = EventId
-            { unEventId = "Ev04BEN3QMSM" }
+            { unEventId = "Ev07KHG83J1F" }
         , teamId = TeamId
             { unTeamId = "T043DB835ML" }
         , eventTime = MkSystemTime
-            { systemSeconds = 1668537593
+            { systemSeconds = 1724952300
             , systemNanoseconds = 0
             }
         , event = EventMessage
             ( MessageEvent
                 { blocks = Nothing
                 , channel = ConversationId
-                    { unConversationId = "C043YJGBY49" }
+                    { unConversationId = "C07KHDGQ7K3" }
                 , text = ""
                 , channelType = Channel
                 , files = Nothing
                 , user = UserId
-                    { unUserId = "U043H11ES4V" }
-                , ts = "1668537593.598469"
+                    { unUserId = "U05JAA9EN4T" }
+                , ts = "1724952300.110719"
                 , threadTs = Nothing
                 , appId = Nothing
                 , botId = Nothing
                 , attachments = Just
                     [ MessageAttachment
-                        { fallback = Just "[October 12th, 2022 4:04 PM] jadel: blahblahblahblahblah"
+                        { fallback = Just "[August 29th, 2024 10:24 AM] lev: 123"
                         , color = Just "D0D0D0"
                         , pretext = Nothing
-                        , authorName = Just "jadel"
-                        , authorLink = Just "https://jadeapptesting.slack.com/team/U043H11ES4V"
-                        , authorIcon = Just "https://secure.gravatar.com/avatar/dcd5bc53dcfaca62ddc3f5726d07ba13.jpg?s=48&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0019-48.png"
+                        , authorName = Just "lev"
+                        , authorLink = Just "https://myworkspace.slack.com/team/U05JAA9EN4T"
+                        , authorIcon = Just "https://avatars.slack-edge.com/2023-07-22/5607926127815_66b9d49327ec16a887e5_48.png"
                         , title = Nothing
                         , titleLink = Nothing
-                        , text = Just "blahblahblahblahblah"
+                        , text = Just "123"
                         , fields = Nothing
                         , imageUrl = Nothing
                         , thumbUrl = Nothing
-                        , footer = Just "Posted in #testing-slack-app"
+                        , footer = Just "Slack Conversation"
                         , footerIcon = Nothing
-                        , ts = Just "1665615886.364019"
+                        , ts = Just "1724952281.623809"
                         , isMsgUnfurl = Just True
                         , messageBlocks = Just
                             [ AttachmentMessageBlock
                                 { team = TeamId
                                     { unTeamId = "T043DB835ML" }
                                 , channel = ConversationId
-                                    { unConversationId = "C043KSKGJUB" }
-                                , ts = "1665615886.364019"
+                                    { unConversationId = "C07KTH1T4CQ" }
+                                , ts = "1724952281.623809"
                                 , message = AttachmentMessageBlockMessage
                                     { blocks =
                                         [ RichText
                                             { blockId = Just
-                                                ( NonEmptyText "TNHa4" )
+                                                ( NonEmptyText "nXUog" )
                                             , elements =
                                                 [ RichTextSectionItemRichText
-                                                    [ RichItemText "blahblahblahblahblah"
+                                                    [ RichItemText "123"
                                                         ( RichStyle
                                                             { rsBold = False
                                                             , rsItalic = False
@@ -69,11 +69,11 @@ EventEventCallback
                             ]
                         , authorId = Just
                             ( UserId
-                                { unUserId = "U043H11ES4V" }
+                                { unUserId = "U05JAA9EN4T" }
                             )
                         , channelId = Just
                             ( ConversationId
-                                { unConversationId = "C043KSKGJUB" }
+                                { unConversationId = "C07KTH1T4CQ" }
                             )
                         , channelTeam = Just
                             ( TeamId
@@ -81,7 +81,7 @@ EventEventCallback
                             )
                         , isAppUnfurl = Nothing
                         , appUnfurlUrl = Nothing
-                        , fromUrl = Just "https://jadeapptesting.slack.com/archives/C043KSKGJUB/p1665615886364019"
+                        , fromUrl = Just "https://myworkspace.slack.com/archives/C07KTH1T4CQ/p1724952281623809"
                         }
                     ]
                 }

--- a/tests/golden/SlackWebhookEvent/forwarded_message.json
+++ b/tests/golden/SlackWebhookEvent/forwarded_message.json
@@ -1,0 +1,78 @@
+{
+    "token": "d90zMGO2eDLrkLHJYcKevn2b",
+    "team_id": "T043DB835ML",
+    "context_team_id": "T043DB835ML",
+    "context_enterprise_id": null,
+    "api_app_id": "A07JRKQPZDH",
+    "event": {
+        "user": "U05JAA9EN4T",
+        "type": "message",
+        "ts": "1724952300.110719",
+        "text": "",
+        "team": "T043DB835ML",
+        "attachments": [
+            {
+                "ts": "1724952281.623809",
+                "author_id": "U05JAA9EN4T",
+                "channel_id": "C07KTH1T4CQ",
+                "channel_team": "T043DB835ML",
+                "is_msg_unfurl": true,
+                "message_blocks": [
+                    {
+                        "team": "T043DB835ML",
+                        "channel": "C07KTH1T4CQ",
+                        "ts": "1724952281.623809",
+                        "message": {
+                            "blocks": [
+                                {
+                                    "type": "rich_text",
+                                    "block_id": "nXUog",
+                                    "elements": [
+                                        {
+                                            "type": "rich_text_section",
+                                            "elements": [
+                                                {
+                                                    "type": "text",
+                                                    "text": "123"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "color": "D0D0D0",
+                "from_url": "https://myworkspace.slack.com/archives/C07KTH1T4CQ/p1724952281623809",
+                "is_share": true,
+                "fallback": "[August 29th, 2024 10:24 AM] lev: 123",
+                "text": "123",
+                "author_name": "lev",
+                "author_link": "https://myworkspace.slack.com/team/U05JAA9EN4T",
+                "author_icon": "https://avatars.slack-edge.com/2023-07-22/5607926127815_66b9d49327ec16a887e5_48.png",
+                "author_subname": "lev",
+                "mrkdwn_in": [
+                    "text"
+                ],
+                "footer": "Slack Conversation"
+            }
+        ],
+        "channel": "C07KHDGQ7K3",
+        "event_ts": "1724952300.110719",
+        "channel_type": "channel"
+    },
+    "type": "event_callback",
+    "event_id": "Ev07KHG83J1F",
+    "event_time": 1724952300,
+    "authorizations": [
+        {
+            "enterprise_id": null,
+            "team_id": "T043DB835ML",
+            "user_id": "U07K4E18KJM",
+            "is_bot": true,
+            "is_enterprise_install": false
+        }
+    ],
+    "is_ext_shared_channel": false
+}

--- a/tests/golden/SlackWebhookEvent/link.golden
+++ b/tests/golden/SlackWebhookEvent/link.golden
@@ -41,6 +41,7 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Nothing
                 , botId = Nothing
+                , attachments = Nothing
                 }
             )
         }

--- a/tests/golden/SlackWebhookEvent/messageExample.golden
+++ b/tests/golden/SlackWebhookEvent/messageExample.golden
@@ -37,6 +37,7 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Nothing
                 , botId = Nothing
+                , attachments = Nothing
                 }
             )
         }

--- a/tests/golden/SlackWebhookEvent/messageIm.golden
+++ b/tests/golden/SlackWebhookEvent/messageIm.golden
@@ -37,6 +37,7 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Nothing
                 , botId = Nothing
+                , attachments = Nothing
                 }
             )
         }

--- a/tests/golden/SlackWebhookEvent/message_file_share.golden
+++ b/tests/golden/SlackWebhookEvent/message_file_share.golden
@@ -52,6 +52,7 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Nothing
                 , botId = Nothing
+                , attachments = Nothing
                 }
             )
         }

--- a/tests/golden/SlackWebhookEvent/message_file_share_slack_connect.golden
+++ b/tests/golden/SlackWebhookEvent/message_file_share_slack_connect.golden
@@ -27,6 +27,7 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Nothing
                 , botId = Nothing
+                , attachments = Nothing
                 }
             )
         }

--- a/tests/golden/SlackWebhookEvent/message_rich_text.golden
+++ b/tests/golden/SlackWebhookEvent/message_rich_text.golden
@@ -79,6 +79,7 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Nothing
                 , botId = Nothing
+                , attachments = Nothing
                 }
             )
         }

--- a/tests/golden/SlackWebhookEvent/message_subtype_bot_message.golden
+++ b/tests/golden/SlackWebhookEvent/message_subtype_bot_message.golden
@@ -39,6 +39,7 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Just "A1BFDR28J"
                 , botId = "B07JWPS5Y5S"
+                , attachments = Nothing
                 }
             )
         }

--- a/tests/golden/SlackWebhookEvent/share_with_message.golden
+++ b/tests/golden/SlackWebhookEvent/share_with_message.golden
@@ -1,60 +1,75 @@
 EventEventCallback
     ( EventCallback
         { eventId = EventId
-            { unEventId = "Ev04BEN3QMSM" }
+            { unEventId = "Ev07K61TELMR" }
         , teamId = TeamId
             { unTeamId = "T043DB835ML" }
         , eventTime = MkSystemTime
-            { systemSeconds = 1668537593
+            { systemSeconds = 1724966800
             , systemNanoseconds = 0
             }
         , event = EventMessage
             ( MessageEvent
-                { blocks = Nothing
+                { blocks = Just
+                    [ RichText
+                        { blockId = Just
+                            ( NonEmptyText "Yyg6K" )
+                        , elements =
+                            [ RichTextSectionItemRichText
+                                [ RichItemText "hello check that out!"
+                                    ( RichStyle
+                                        { rsBold = False
+                                        , rsItalic = False
+                                        }
+                                    )
+                                ]
+                            ]
+                        }
+                    ]
                 , channel = ConversationId
-                    { unConversationId = "C043YJGBY49" }
-                , text = ""
+                    { unConversationId = "C07KHDGQ7K3" }
+                , text = "hello check that out!"
                 , channelType = Channel
                 , files = Nothing
                 , user = UserId
-                    { unUserId = "U043H11ES4V" }
-                , ts = "1668537593.598469"
+                    { unUserId = "U05JAA9EN4T" }
+                , ts = "1724966800.923979"
                 , threadTs = Nothing
                 , appId = Nothing
                 , botId = Nothing
                 , attachments = Just
                     [ MessageAttachment
-                        { fallback = Just "[October 12th, 2022 4:04 PM] jadel: blahblahblahblahblah"
+                        { fallback = Just "[August 29th, 2024 2:26 PM] lev: this will be shared with a message"
                         , color = Just "D0D0D0"
                         , pretext = Nothing
-                        , authorName = Just "jadel"
-                        , authorLink = Just "https://jadeapptesting.slack.com/team/U043H11ES4V"
-                        , authorIcon = Just "https://secure.gravatar.com/avatar/dcd5bc53dcfaca62ddc3f5726d07ba13.jpg?s=48&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0019-48.png"
+                        , authorName = Just "lev"
+                        , authorLink = Just "https://myworkspace.slack.com/team/U05JAA9EN4T"
+                        , authorIcon = Just "https://avatars.slack-edge.com/2023-07-22/5607926127815_66b9d49327ec16a887e5_48.png"
                         , title = Nothing
                         , titleLink = Nothing
-                        , text = Just "blahblahblahblahblah"
+                        , text = Just "this will be shared with a message"
                         , fields = Nothing
                         , imageUrl = Nothing
                         , thumbUrl = Nothing
-                        , footer = Just "Posted in #testing-slack-app"
+                        , footer = Just "Slack Conversation"
                         , footerIcon = Nothing
-                        , ts = Just "1665615886.364019"
+                        , ts = Just "1724966776.474889"
                         , isMsgUnfurl = Just True
                         , messageBlocks = Just
                             [ AttachmentMessageBlock
                                 { team = TeamId
                                     { unTeamId = "T043DB835ML" }
                                 , channel = ConversationId
-                                    { unConversationId = "C043KSKGJUB" }
-                                , ts = "1665615886.364019"
+                                    { unConversationId = "C07KTH1T4CQ" }
+                                , ts = "1724966776.474889"
                                 , message = AttachmentMessageBlockMessage
                                     { blocks =
                                         [ RichText
                                             { blockId = Just
-                                                ( NonEmptyText "TNHa4" )
+                                                ( NonEmptyText "BXn1o" )
                                             , elements =
                                                 [ RichTextSectionItemRichText
-                                                    [ RichItemText "blahblahblahblahblah"
+                                                    [ RichItemText "this will be shared with a message"
                                                         ( RichStyle
                                                             { rsBold = False
                                                             , rsItalic = False
@@ -69,11 +84,11 @@ EventEventCallback
                             ]
                         , authorId = Just
                             ( UserId
-                                { unUserId = "U043H11ES4V" }
+                                { unUserId = "U05JAA9EN4T" }
                             )
                         , channelId = Just
                             ( ConversationId
-                                { unConversationId = "C043KSKGJUB" }
+                                { unConversationId = "C07KTH1T4CQ" }
                             )
                         , channelTeam = Just
                             ( TeamId
@@ -81,7 +96,7 @@ EventEventCallback
                             )
                         , isAppUnfurl = Nothing
                         , appUnfurlUrl = Nothing
-                        , fromUrl = Just "https://jadeapptesting.slack.com/archives/C043KSKGJUB/p1665615886364019"
+                        , fromUrl = Just "https://myworkspace.slack.com/archives/C07KTH1T4CQ/p1724966776474889"
                         }
                     ]
                 }

--- a/tests/golden/SlackWebhookEvent/share_with_message.json
+++ b/tests/golden/SlackWebhookEvent/share_with_message.json
@@ -1,0 +1,95 @@
+{
+    "token": "d90zMGO2eDLrkLHJYcKevn2b",
+    "team_id": "T043DB835ML",
+    "context_team_id": "T043DB835ML",
+    "context_enterprise_id": null,
+    "api_app_id": "A07JRKQPZDH",
+    "event": {
+        "user": "U05JAA9EN4T",
+        "type": "message",
+        "ts": "1724966800.923979",
+        "text": "hello check that out!",
+        "team": "T043DB835ML",
+        "attachments": [
+            {
+                "ts": "1724966776.474889",
+                "author_id": "U05JAA9EN4T",
+                "channel_id": "C07KTH1T4CQ",
+                "channel_team": "T043DB835ML",
+                "is_msg_unfurl": true,
+                "message_blocks": [
+                    {
+                        "team": "T043DB835ML",
+                        "channel": "C07KTH1T4CQ",
+                        "ts": "1724966776.474889",
+                        "message": {
+                            "blocks": [
+                                {
+                                    "type": "rich_text",
+                                    "block_id": "BXn1o",
+                                    "elements": [
+                                        {
+                                            "type": "rich_text_section",
+                                            "elements": [
+                                                {
+                                                    "type": "text",
+                                                    "text": "this will be shared with a message"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "color": "D0D0D0",
+                "from_url": "https://myworkspace.slack.com/archives/C07KTH1T4CQ/p1724966776474889",
+                "is_share": true,
+                "fallback": "[August 29th, 2024 2:26 PM] lev: this will be shared with a message",
+                "text": "this will be shared with a message",
+                "author_name": "lev",
+                "author_link": "https://myworkspace.slack.com/team/U05JAA9EN4T",
+                "author_icon": "https://avatars.slack-edge.com/2023-07-22/5607926127815_66b9d49327ec16a887e5_48.png",
+                "author_subname": "lev",
+                "mrkdwn_in": [
+                    "text"
+                ],
+                "footer": "Slack Conversation"
+            }
+        ],
+        "blocks": [
+            {
+                "type": "rich_text",
+                "block_id": "Yyg6K",
+                "elements": [
+                    {
+                        "type": "rich_text_section",
+                        "elements": [
+                            {
+                                "type": "text",
+                                "text": "hello check that out!"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "channel": "C07KHDGQ7K3",
+        "event_ts": "1724966800.923979",
+        "channel_type": "channel"
+    },
+    "type": "event_callback",
+    "event_id": "Ev07K61TELMR",
+    "event_time": 1724966800,
+    "authorizations": [
+        {
+            "enterprise_id": null,
+            "team_id": "T043DB835ML",
+            "user_id": "U07K4E18KJM",
+            "is_bot": true,
+            "is_enterprise_install": false
+        }
+    ],
+    "is_ext_shared_channel": false
+}

--- a/tests/golden/SlackWebhookEvent/slackbotIm.golden
+++ b/tests/golden/SlackWebhookEvent/slackbotIm.golden
@@ -46,6 +46,7 @@ EventEventCallback
                 , threadTs = Nothing
                 , appId = Nothing
                 , botId = Nothing
+                , attachments = Nothing
                 }
             )
         }


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->

Adds support for events to deserialize message attachments using all documented fields, ported from https://github.com/slackapi/node-slack-sdk/blob/fc87d51/packages/types/src/message-attachments.ts 

As well as some undocumented fields discovered via manual testing