### PR TITLE
better attachment support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.0.4 (2024-09-15)
+* [#135](https://github.com/MercuryTechnologies/slack-web/pull/135)
+  Improves attachement support by providing clients wih the raw JSON value
+  in case of a parse failure.
+
 # 2.0.0.3 (2024-08-30)
 * [#133](https://github.com/MercuryTechnologies/slack-web/pull/133)
   Adds attachment support for message event subscriptions.

--- a/slack-web.cabal
+++ b/slack-web.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name: slack-web
-version: 2.0.0.3
+version: 2.0.0.4
 
 build-type: Simple
 

--- a/src/Web/Slack/Experimental/Events/Types.hs
+++ b/src/Web/Slack/Experimental/Events/Types.hs
@@ -172,9 +172,7 @@ data MessageEvent = MessageEvent
   -- ^ Present if it's sent by a bot user
   , attachments :: Maybe [MessageAttachment]
   -- ^ @since 2.0.0.3
-  -- Present if the message has attachments. Slack doesn't have very good documentation about
-  -- the schema for message attachements, so if we're unable to decode it we'll just give the client
-  -- back an aeson Value to work with.
+  -- Present if the message has attachments
   }
   deriving stock (Show)
 

--- a/src/Web/Slack/Experimental/Events/Types.hs
+++ b/src/Web/Slack/Experimental/Events/Types.hs
@@ -122,7 +122,7 @@ instance FromJSON DecodedMessageAttachment where
       parseTs :: Value -> Parser (Maybe Text)
       parseTs (String s) = pure $ Just s
       parseTs (Number n) =
-        let s = show (Sci.formatScientific Sci.Fixed Nothing n)
+        let s = Sci.formatScientific Sci.Fixed Nothing n
             formatted = if '.' `elem` s then s else s ++ ".000000"
          in pure $ Just (pack formatted)
       parseTs _ = pure Nothing

--- a/tests/Web/Slack/Experimental/Events/TypesSpec.hs
+++ b/tests/Web/Slack/Experimental/Events/TypesSpec.hs
@@ -30,5 +30,6 @@ spec = describe "Types for Slack events" do
         , "message_subtype_bot_message"
         , "forwarded_message"
         , "github_notification"
+        , "github_notification_ts_string"
         , "non_spec_attachment"
         ]

--- a/tests/Web/Slack/Experimental/Events/TypesSpec.hs
+++ b/tests/Web/Slack/Experimental/Events/TypesSpec.hs
@@ -31,5 +31,6 @@ spec = describe "Types for Slack events" do
         , "forwarded_message"
         , "github_notification"
         , "github_notification_ts_string"
+        , "github_with_link"
         , "non_spec_attachment"
         ]

--- a/tests/Web/Slack/Experimental/Events/TypesSpec.hs
+++ b/tests/Web/Slack/Experimental/Events/TypesSpec.hs
@@ -29,4 +29,6 @@ spec = describe "Types for Slack events" do
           "email_message"
         , "message_subtype_bot_message"
         , "forwarded_message"
+        , "github_notification"
+        , "non_spec_attachment"
         ]

--- a/tests/golden/SlackWebhookEvent/forwarded_message.golden
+++ b/tests/golden/SlackWebhookEvent/forwarded_message.golden
@@ -24,64 +24,212 @@ EventEventCallback
                 , botId = Nothing
                 , attachments = Just
                     [ MessageAttachment
-                        { fallback = Just "[August 29th, 2024 10:24 AM] lev: 123"
-                        , color = Just "D0D0D0"
-                        , pretext = Nothing
-                        , authorName = Just "lev"
-                        , authorLink = Just "https://myworkspace.slack.com/team/U05JAA9EN4T"
-                        , authorIcon = Just "https://avatars.slack-edge.com/2023-07-22/5607926127815_66b9d49327ec16a887e5_48.png"
-                        , title = Nothing
-                        , titleLink = Nothing
-                        , text = Just "123"
-                        , fields = Nothing
-                        , imageUrl = Nothing
-                        , thumbUrl = Nothing
-                        , footer = Just "Slack Conversation"
-                        , footerIcon = Nothing
-                        , ts = Just "1724952281.623809"
-                        , isMsgUnfurl = Just True
-                        , messageBlocks = Just
-                            [ AttachmentMessageBlock
-                                { team = TeamId
-                                    { unTeamId = "T043DB835ML" }
-                                , channel = ConversationId
-                                    { unConversationId = "C07KTH1T4CQ" }
-                                , ts = "1724952281.623809"
-                                , message = AttachmentMessageBlockMessage
-                                    { blocks =
-                                        [ RichText
-                                            { blockId = Just
-                                                ( NonEmptyText "nXUog" )
-                                            , elements =
-                                                [ RichTextSectionItemRichText
-                                                    [ RichItemText "123"
-                                                        ( RichStyle
-                                                            { rsBold = False
-                                                            , rsItalic = False
-                                                            }
-                                                        )
-                                                    ]
+                        { decoded = Just
+                            ( DecodedMessageAttachment
+                                { fallback = Just "[August 29th, 2024 10:24 AM] lev: 123"
+                                , color = Just "D0D0D0"
+                                , pretext = Nothing
+                                , authorName = Just "lev"
+                                , authorLink = Just "https://myworkspace.slack.com/team/U05JAA9EN4T"
+                                , authorIcon = Just "https://avatars.slack-edge.com/2023-07-22/5607926127815_66b9d49327ec16a887e5_48.png"
+                                , title = Nothing
+                                , titleLink = Nothing
+                                , text = Just "123"
+                                , fields = Nothing
+                                , imageUrl = Nothing
+                                , thumbUrl = Nothing
+                                , footer = Just "Slack Conversation"
+                                , footerIcon = Nothing
+                                , ts = Just "1724952281.623809"
+                                , isMsgUnfurl = Just True
+                                , messageBlocks = Just
+                                    [ AttachmentMessageBlock
+                                        { team = TeamId
+                                            { unTeamId = "T043DB835ML" }
+                                        , channel = ConversationId
+                                            { unConversationId = "C07KTH1T4CQ" }
+                                        , ts = "1724952281.623809"
+                                        , message = AttachmentMessageBlockMessage
+                                            { blocks =
+                                                [ RichText
+                                                    { blockId = Just
+                                                        ( NonEmptyText "nXUog" )
+                                                    , elements =
+                                                        [ RichTextSectionItemRichText
+                                                            [ RichItemText "123"
+                                                                ( RichStyle
+                                                                    { rsBold = False
+                                                                    , rsItalic = False
+                                                                    }
+                                                                )
+                                                            ]
+                                                        ]
+                                                    }
                                                 ]
                                             }
-                                        ]
-                                    }
+                                        }
+                                    ]
+                                , authorId = Just
+                                    ( UserId
+                                        { unUserId = "U05JAA9EN4T" }
+                                    )
+                                , channelId = Just
+                                    ( ConversationId
+                                        { unConversationId = "C07KTH1T4CQ" }
+                                    )
+                                , channelTeam = Just
+                                    ( TeamId
+                                        { unTeamId = "T043DB835ML" }
+                                    )
+                                , isAppUnfurl = Nothing
+                                , appUnfurlUrl = Nothing
+                                , fromUrl = Just "https://myworkspace.slack.com/archives/C07KTH1T4CQ/p1724952281623809"
                                 }
-                            ]
-                        , authorId = Just
-                            ( UserId
-                                { unUserId = "U05JAA9EN4T" }
                             )
-                        , channelId = Just
-                            ( ConversationId
-                                { unConversationId = "C07KTH1T4CQ" }
+                        , raw = Object
+                            ( fromList
+                                [
+                                    ( "author_icon"
+                                    , String "https://avatars.slack-edge.com/2023-07-22/5607926127815_66b9d49327ec16a887e5_48.png"
+                                    )
+                                ,
+                                    ( "author_id"
+                                    , String "U05JAA9EN4T"
+                                    )
+                                ,
+                                    ( "author_link"
+                                    , String "https://myworkspace.slack.com/team/U05JAA9EN4T"
+                                    )
+                                ,
+                                    ( "author_name"
+                                    , String "lev"
+                                    )
+                                ,
+                                    ( "author_subname"
+                                    , String "lev"
+                                    )
+                                ,
+                                    ( "channel_id"
+                                    , String "C07KTH1T4CQ"
+                                    )
+                                ,
+                                    ( "channel_team"
+                                    , String "T043DB835ML"
+                                    )
+                                ,
+                                    ( "color"
+                                    , String "D0D0D0"
+                                    )
+                                ,
+                                    ( "fallback"
+                                    , String "[August 29th, 2024 10:24 AM] lev: 123"
+                                    )
+                                ,
+                                    ( "footer"
+                                    , String "Slack Conversation"
+                                    )
+                                ,
+                                    ( "from_url"
+                                    , String "https://myworkspace.slack.com/archives/C07KTH1T4CQ/p1724952281623809"
+                                    )
+                                ,
+                                    ( "is_msg_unfurl"
+                                    , Bool True
+                                    )
+                                ,
+                                    ( "is_share"
+                                    , Bool True
+                                    )
+                                ,
+                                    ( "message_blocks"
+                                    , Array
+                                        [ Object
+                                            ( fromList
+                                                [
+                                                    ( "channel"
+                                                    , String "C07KTH1T4CQ"
+                                                    )
+                                                ,
+                                                    ( "message"
+                                                    , Object
+                                                        ( fromList
+                                                            [
+                                                                ( "blocks"
+                                                                , Array
+                                                                    [ Object
+                                                                        ( fromList
+                                                                            [
+                                                                                ( "block_id"
+                                                                                , String "nXUog"
+                                                                                )
+                                                                            ,
+                                                                                ( "elements"
+                                                                                , Array
+                                                                                    [ Object
+                                                                                        ( fromList
+                                                                                            [
+                                                                                                ( "elements"
+                                                                                                , Array
+                                                                                                    [ Object
+                                                                                                        ( fromList
+                                                                                                            [
+                                                                                                                ( "text"
+                                                                                                                , String "123"
+                                                                                                                )
+                                                                                                            ,
+                                                                                                                ( "type"
+                                                                                                                , String "text"
+                                                                                                                )
+                                                                                                            ]
+                                                                                                        )
+                                                                                                    ]
+                                                                                                )
+                                                                                            ,
+                                                                                                ( "type"
+                                                                                                , String "rich_text_section"
+                                                                                                )
+                                                                                            ]
+                                                                                        )
+                                                                                    ]
+                                                                                )
+                                                                            ,
+                                                                                ( "type"
+                                                                                , String "rich_text"
+                                                                                )
+                                                                            ]
+                                                                        )
+                                                                    ]
+                                                                )
+                                                            ]
+                                                        )
+                                                    )
+                                                ,
+                                                    ( "team"
+                                                    , String "T043DB835ML"
+                                                    )
+                                                ,
+                                                    ( "ts"
+                                                    , String "1724952281.623809"
+                                                    )
+                                                ]
+                                            )
+                                        ]
+                                    )
+                                ,
+                                    ( "mrkdwn_in"
+                                    , Array
+                                        [ String "text" ]
+                                    )
+                                ,
+                                    ( "text"
+                                    , String "123"
+                                    )
+                                ,
+                                    ( "ts"
+                                    , String "1724952281.623809"
+                                    )
+                                ]
                             )
-                        , channelTeam = Just
-                            ( TeamId
-                                { unTeamId = "T043DB835ML" }
-                            )
-                        , isAppUnfurl = Nothing
-                        , appUnfurlUrl = Nothing
-                        , fromUrl = Just "https://myworkspace.slack.com/archives/C07KTH1T4CQ/p1724952281623809"
                         }
                     ]
                 }

--- a/tests/golden/SlackWebhookEvent/forwarded_message.json
+++ b/tests/golden/SlackWebhookEvent/forwarded_message.json
@@ -1,5 +1,5 @@
 {
-    "token": "d90zMGO2eDLrkLHJYcKevn2b",
+    "token": "aaaa",
     "team_id": "T043DB835ML",
     "context_team_id": "T043DB835ML",
     "context_enterprise_id": null,

--- a/tests/golden/SlackWebhookEvent/github_notification.golden
+++ b/tests/golden/SlackWebhookEvent/github_notification.golden
@@ -1,0 +1,197 @@
+EventEventCallback
+    ( EventCallback
+        { eventId = EventId
+            { unEventId = "Ev07MH6R7FDE" }
+        , teamId = TeamId
+            { unTeamId = "T043DB835ML" }
+        , eventTime = MkSystemTime
+            { systemSeconds = 1725998548
+            , systemNanoseconds = 0
+            }
+        , event = EventMessage
+            ( MessageEvent
+                { blocks = Nothing
+                , channel = ConversationId
+                    { unConversationId = "C07LRFB3C8M" }
+                , text = ""
+                , channelType = Channel
+                , files = Nothing
+                , user = UserId
+                    { unUserId = "U07M725KAD7" }
+                , ts = "1725998548.581159"
+                , threadTs = Nothing
+                , appId = Just "A01BP7R4KNY"
+                , botId = Just "B07LDR01Z63"
+                , attachments = Just
+                    [ MessageAttachment
+                        { decoded = Just
+                            ( DecodedMessageAttachment
+                                { fallback = Just "[myorg/myrepo] Issue opened by ldub"
+                                , color = Just "36a64f"
+                                , pretext = Just "Issue created by <https://github.com/ldub|ldub>"
+                                , authorName = Nothing
+                                , authorLink = Nothing
+                                , authorIcon = Nothing
+                                , title = Just "<https://github.com/myorg/myrepo/issues/2|#2 test issue 2>"
+                                , titleLink = Nothing
+                                , text = Just "another oneeeee"
+                                , fields = Nothing
+                                , imageUrl = Nothing
+                                , thumbUrl = Nothing
+                                , footer = Just "<https://github.com/myorg/myrepo|myorg/myrepo>"
+                                , footerIcon = Just "https://slack.github.com/static/img/favicon-neutral.png"
+                                , ts = Just ""1725998545.0""
+                                , isMsgUnfurl = Nothing
+                                , messageBlocks = Nothing
+                                , authorId = Nothing
+                                , channelId = Nothing
+                                , channelTeam = Nothing
+                                , isAppUnfurl = Nothing
+                                , appUnfurlUrl = Nothing
+                                , fromUrl = Nothing
+                                }
+                            )
+                        , raw = Object
+                            ( fromList
+                                [
+                                    ( "actions"
+                                    , Array
+                                        [ Object
+                                            ( fromList
+                                                [
+                                                    ( "id"
+                                                    , String "1"
+                                                    )
+                                                ,
+                                                    ( "name"
+                                                    , String "comment"
+                                                    )
+                                                ,
+                                                    ( "style"
+                                                    , String ""
+                                                    )
+                                                ,
+                                                    ( "text"
+                                                    , String "Comment"
+                                                    )
+                                                ,
+                                                    ( "type"
+                                                    , String "button"
+                                                    )
+                                                ,
+                                                    ( "value"
+                                                    , String "{&amp;amp;quot;selectedOrg&amp;amp;quot;:&amp;amp;quot;myorg&amp;amp;quot;,&amp;amp;quot;selectedOrgId&amp;amp;quot;:140364112,&amp;amp;quot;selectedRepo&amp;amp;quot;:&amp;amp;quot;myrepo&amp;amp;quot;,&amp;amp;quot;selectedRepoId&amp;amp;quot;:809927288,&amp;amp;quot;issueNumber&amp;amp;quot;:2,&amp;amp;quot;issueHtmlUrl&amp;amp;quot;:&amp;amp;quot;https://github.com/myorg/myrepo/issues/2&amp;amp;quot;,&amp;amp;quot;issueTitle&amp;amp;quot;:&amp;amp;quot;test issue 2&amp;amp;quot;}"
+                                                    )
+                                                ]
+                                            )
+                                        , Object
+                                            ( fromList
+                                                [
+                                                    ( "id"
+                                                    , String "2"
+                                                    )
+                                                ,
+                                                    ( "name"
+                                                    , String "edit"
+                                                    )
+                                                ,
+                                                    ( "style"
+                                                    , String ""
+                                                    )
+                                                ,
+                                                    ( "text"
+                                                    , String "Edit"
+                                                    )
+                                                ,
+                                                    ( "type"
+                                                    , String "button"
+                                                    )
+                                                ,
+                                                    ( "value"
+                                                    , String "{&amp;amp;quot;selectedOrg&amp;amp;quot;:&amp;amp;quot;myorg&amp;amp;quot;,&amp;amp;quot;selectedOrgId&amp;amp;quot;:140364112,&amp;amp;quot;selectedRepo&amp;amp;quot;:&amp;amp;quot;myrepo&amp;amp;quot;,&amp;amp;quot;selectedRepoId&amp;amp;quot;:809927288,&amp;amp;quot;issueNumber&amp;amp;quot;:2,&amp;amp;quot;issueHtmlUrl&amp;amp;quot;:&amp;amp;quot;https://github.com/myorg/myrepo/issues/2&amp;amp;quot;,&amp;amp;quot;issueTitle&amp;amp;quot;:&amp;amp;quot;test issue 2&amp;amp;quot;}"
+                                                    )
+                                                ]
+                                            )
+                                        , Object
+                                            ( fromList
+                                                [
+                                                    ( "id"
+                                                    , String "3"
+                                                    )
+                                                ,
+                                                    ( "name"
+                                                    , String "close"
+                                                    )
+                                                ,
+                                                    ( "style"
+                                                    , String "danger"
+                                                    )
+                                                ,
+                                                    ( "text"
+                                                    , String "Close"
+                                                    )
+                                                ,
+                                                    ( "type"
+                                                    , String "button"
+                                                    )
+                                                ,
+                                                    ( "value"
+                                                    , String "{&amp;amp;quot;selectedOrg&amp;amp;quot;:&amp;amp;quot;myorg&amp;amp;quot;,&amp;amp;quot;selectedOrgId&amp;amp;quot;:140364112,&amp;amp;quot;selectedRepo&amp;amp;quot;:&amp;amp;quot;myrepo&amp;amp;quot;,&amp;amp;quot;selectedRepoId&amp;amp;quot;:809927288,&amp;amp;quot;issueNumber&amp;amp;quot;:2,&amp;amp;quot;issueHtmlUrl&amp;amp;quot;:&amp;amp;quot;https://github.com/myorg/myrepo/issues/2&amp;amp;quot;,&amp;amp;quot;issueTitle&amp;amp;quot;:&amp;amp;quot;test issue 2&amp;amp;quot;}"
+                                                    )
+                                                ]
+                                            )
+                                        ]
+                                    )
+                                ,
+                                    ( "callback_id"
+                                    , String "issue-opened-interaction"
+                                    )
+                                ,
+                                    ( "color"
+                                    , String "36a64f"
+                                    )
+                                ,
+                                    ( "fallback"
+                                    , String "[myorg/myrepo] Issue opened by ldub"
+                                    )
+                                ,
+                                    ( "footer"
+                                    , String "<https://github.com/myorg/myrepo|myorg/myrepo>"
+                                    )
+                                ,
+                                    ( "footer_icon"
+                                    , String "https://slack.github.com/static/img/favicon-neutral.png"
+                                    )
+                                ,
+                                    ( "id"
+                                    , Number 1.0
+                                    )
+                                ,
+                                    ( "mrkdwn_in"
+                                    , Array
+                                        [ String "text" ]
+                                    )
+                                ,
+                                    ( "pretext"
+                                    , String "Issue created by <https://github.com/ldub|ldub>"
+                                    )
+                                ,
+                                    ( "text"
+                                    , String "another oneeeee"
+                                    )
+                                ,
+                                    ( "title"
+                                    , String "<https://github.com/myorg/myrepo/issues/2|#2 test issue 2>"
+                                    )
+                                ,
+                                    ( "ts"
+                                    , Number 1.725998545e9
+                                    )
+                                ]
+                            )
+                        }
+                    ]
+                }
+            )
+        }
+    )

--- a/tests/golden/SlackWebhookEvent/github_notification.json
+++ b/tests/golden/SlackWebhookEvent/github_notification.json
@@ -1,0 +1,88 @@
+{
+    "token": "aaaa",
+    "team_id": "T043DB835ML",
+    "context_team_id": "T043DB835ML",
+    "context_enterprise_id": null,
+    "api_app_id": "A07JRKQPZDH",
+    "event": {
+        "user": "U07M725KAD7",
+        "type": "message",
+        "ts": "1725998548.581159",
+        "bot_id": "B07LDR01Z63",
+        "app_id": "A01BP7R4KNY",
+        "text": "",
+        "team": "T043DB835ML",
+        "bot_profile": {
+            "id": "B07LDR01Z63",
+            "deleted": false,
+            "name": "GitHub",
+            "updated": 1725998199,
+            "app_id": "A01BP7R4KNY",
+            "icons": {
+                "image_36": "https://avatars.slack-edge.com/2020-11-25/1527503386626_319578f21381f9641cd8_36.png",
+                "image_48": "https://avatars.slack-edge.com/2020-11-25/1527503386626_319578f21381f9641cd8_48.png",
+                "image_72": "https://avatars.slack-edge.com/2020-11-25/1527503386626_319578f21381f9641cd8_72.png"
+            },
+            "team_id": "T043DB835ML"
+        },
+        "attachments": [
+            {
+                "id": 1,
+                "footer_icon": "https://slack.github.com/static/img/favicon-neutral.png",
+                "ts": 1725998545,
+                "color": "36a64f",
+                "fallback": "[myorg/myrepo] Issue opened by ldub",
+                "text": "another oneeeee",
+                "pretext": "Issue created by <https://github.com/ldub|ldub>",
+                "title": "<https://github.com/myorg/myrepo/issues/2|#2 test issue 2>",
+                "callback_id": "issue-opened-interaction",
+                "footer": "<https://github.com/myorg/myrepo|myorg/myrepo>",
+                "mrkdwn_in": [
+                    "text"
+                ],
+                "actions": [
+                    {
+                        "id": "1",
+                        "name": "comment",
+                        "text": "Comment",
+                        "type": "button",
+                        "value": "{&amp;amp;quot;selectedOrg&amp;amp;quot;:&amp;amp;quot;myorg&amp;amp;quot;,&amp;amp;quot;selectedOrgId&amp;amp;quot;:140364112,&amp;amp;quot;selectedRepo&amp;amp;quot;:&amp;amp;quot;myrepo&amp;amp;quot;,&amp;amp;quot;selectedRepoId&amp;amp;quot;:809927288,&amp;amp;quot;issueNumber&amp;amp;quot;:2,&amp;amp;quot;issueHtmlUrl&amp;amp;quot;:&amp;amp;quot;https://github.com/myorg/myrepo/issues/2&amp;amp;quot;,&amp;amp;quot;issueTitle&amp;amp;quot;:&amp;amp;quot;test issue 2&amp;amp;quot;}",
+                        "style": ""
+                    },
+                    {
+                        "id": "2",
+                        "name": "edit",
+                        "text": "Edit",
+                        "type": "button",
+                        "value": "{&amp;amp;quot;selectedOrg&amp;amp;quot;:&amp;amp;quot;myorg&amp;amp;quot;,&amp;amp;quot;selectedOrgId&amp;amp;quot;:140364112,&amp;amp;quot;selectedRepo&amp;amp;quot;:&amp;amp;quot;myrepo&amp;amp;quot;,&amp;amp;quot;selectedRepoId&amp;amp;quot;:809927288,&amp;amp;quot;issueNumber&amp;amp;quot;:2,&amp;amp;quot;issueHtmlUrl&amp;amp;quot;:&amp;amp;quot;https://github.com/myorg/myrepo/issues/2&amp;amp;quot;,&amp;amp;quot;issueTitle&amp;amp;quot;:&amp;amp;quot;test issue 2&amp;amp;quot;}",
+                        "style": ""
+                    },
+                    {
+                        "id": "3",
+                        "name": "close",
+                        "text": "Close",
+                        "type": "button",
+                        "value": "{&amp;amp;quot;selectedOrg&amp;amp;quot;:&amp;amp;quot;myorg&amp;amp;quot;,&amp;amp;quot;selectedOrgId&amp;amp;quot;:140364112,&amp;amp;quot;selectedRepo&amp;amp;quot;:&amp;amp;quot;myrepo&amp;amp;quot;,&amp;amp;quot;selectedRepoId&amp;amp;quot;:809927288,&amp;amp;quot;issueNumber&amp;amp;quot;:2,&amp;amp;quot;issueHtmlUrl&amp;amp;quot;:&amp;amp;quot;https://github.com/myorg/myrepo/issues/2&amp;amp;quot;,&amp;amp;quot;issueTitle&amp;amp;quot;:&amp;amp;quot;test issue 2&amp;amp;quot;}",
+                        "style": "danger"
+                    }
+                ]
+            }
+        ],
+        "channel": "C07LRFB3C8M",
+        "event_ts": "1725998548.581159",
+        "channel_type": "channel"
+    },
+    "type": "event_callback",
+    "event_id": "Ev07MH6R7FDE",
+    "event_time": 1725998548,
+    "authorizations": [
+        {
+            "enterprise_id": null,
+            "team_id": "T043DB835ML",
+            "user_id": "U07K4E18KJM",
+            "is_bot": true,
+            "is_enterprise_install": false
+        }
+    ],
+    "is_ext_shared_channel": false
+}

--- a/tests/golden/SlackWebhookEvent/github_notification_ts_string.golden
+++ b/tests/golden/SlackWebhookEvent/github_notification_ts_string.golden
@@ -40,7 +40,7 @@ EventEventCallback
                                 , thumbUrl = Nothing
                                 , footer = Just "<https://github.com/myorg/myrepo|myorg/myrepo>"
                                 , footerIcon = Just "https://slack.github.com/static/img/favicon-neutral.png"
-                                , ts = Just "1725998545.0"
+                                , ts = Just "1725998545.123456"
                                 , isMsgUnfurl = Nothing
                                 , messageBlocks = Nothing
                                 , authorId = Nothing
@@ -185,7 +185,7 @@ EventEventCallback
                                     )
                                 ,
                                     ( "ts"
-                                    , Number 1.725998545e9
+                                    , String "1725998545.123456"
                                     )
                                 ]
                             )

--- a/tests/golden/SlackWebhookEvent/github_notification_ts_string.json
+++ b/tests/golden/SlackWebhookEvent/github_notification_ts_string.json
@@ -1,0 +1,88 @@
+{
+    "token": "aaaa",
+    "team_id": "T043DB835ML",
+    "context_team_id": "T043DB835ML",
+    "context_enterprise_id": null,
+    "api_app_id": "A07JRKQPZDH",
+    "event": {
+        "user": "U07M725KAD7",
+        "type": "message",
+        "ts": "1725998548.581159",
+        "bot_id": "B07LDR01Z63",
+        "app_id": "A01BP7R4KNY",
+        "text": "",
+        "team": "T043DB835ML",
+        "bot_profile": {
+            "id": "B07LDR01Z63",
+            "deleted": false,
+            "name": "GitHub",
+            "updated": 1725998199,
+            "app_id": "A01BP7R4KNY",
+            "icons": {
+                "image_36": "https://avatars.slack-edge.com/2020-11-25/1527503386626_319578f21381f9641cd8_36.png",
+                "image_48": "https://avatars.slack-edge.com/2020-11-25/1527503386626_319578f21381f9641cd8_48.png",
+                "image_72": "https://avatars.slack-edge.com/2020-11-25/1527503386626_319578f21381f9641cd8_72.png"
+            },
+            "team_id": "T043DB835ML"
+        },
+        "attachments": [
+            {
+                "id": 1,
+                "footer_icon": "https://slack.github.com/static/img/favicon-neutral.png",
+                "ts": "1725998545.123456",
+                "color": "36a64f",
+                "fallback": "[myorg/myrepo] Issue opened by ldub",
+                "text": "another oneeeee",
+                "pretext": "Issue created by <https://github.com/ldub|ldub>",
+                "title": "<https://github.com/myorg/myrepo/issues/2|#2 test issue 2>",
+                "callback_id": "issue-opened-interaction",
+                "footer": "<https://github.com/myorg/myrepo|myorg/myrepo>",
+                "mrkdwn_in": [
+                    "text"
+                ],
+                "actions": [
+                    {
+                        "id": "1",
+                        "name": "comment",
+                        "text": "Comment",
+                        "type": "button",
+                        "value": "{&amp;amp;quot;selectedOrg&amp;amp;quot;:&amp;amp;quot;myorg&amp;amp;quot;,&amp;amp;quot;selectedOrgId&amp;amp;quot;:140364112,&amp;amp;quot;selectedRepo&amp;amp;quot;:&amp;amp;quot;myrepo&amp;amp;quot;,&amp;amp;quot;selectedRepoId&amp;amp;quot;:809927288,&amp;amp;quot;issueNumber&amp;amp;quot;:2,&amp;amp;quot;issueHtmlUrl&amp;amp;quot;:&amp;amp;quot;https://github.com/myorg/myrepo/issues/2&amp;amp;quot;,&amp;amp;quot;issueTitle&amp;amp;quot;:&amp;amp;quot;test issue 2&amp;amp;quot;}",
+                        "style": ""
+                    },
+                    {
+                        "id": "2",
+                        "name": "edit",
+                        "text": "Edit",
+                        "type": "button",
+                        "value": "{&amp;amp;quot;selectedOrg&amp;amp;quot;:&amp;amp;quot;myorg&amp;amp;quot;,&amp;amp;quot;selectedOrgId&amp;amp;quot;:140364112,&amp;amp;quot;selectedRepo&amp;amp;quot;:&amp;amp;quot;myrepo&amp;amp;quot;,&amp;amp;quot;selectedRepoId&amp;amp;quot;:809927288,&amp;amp;quot;issueNumber&amp;amp;quot;:2,&amp;amp;quot;issueHtmlUrl&amp;amp;quot;:&amp;amp;quot;https://github.com/myorg/myrepo/issues/2&amp;amp;quot;,&amp;amp;quot;issueTitle&amp;amp;quot;:&amp;amp;quot;test issue 2&amp;amp;quot;}",
+                        "style": ""
+                    },
+                    {
+                        "id": "3",
+                        "name": "close",
+                        "text": "Close",
+                        "type": "button",
+                        "value": "{&amp;amp;quot;selectedOrg&amp;amp;quot;:&amp;amp;quot;myorg&amp;amp;quot;,&amp;amp;quot;selectedOrgId&amp;amp;quot;:140364112,&amp;amp;quot;selectedRepo&amp;amp;quot;:&amp;amp;quot;myrepo&amp;amp;quot;,&amp;amp;quot;selectedRepoId&amp;amp;quot;:809927288,&amp;amp;quot;issueNumber&amp;amp;quot;:2,&amp;amp;quot;issueHtmlUrl&amp;amp;quot;:&amp;amp;quot;https://github.com/myorg/myrepo/issues/2&amp;amp;quot;,&amp;amp;quot;issueTitle&amp;amp;quot;:&amp;amp;quot;test issue 2&amp;amp;quot;}",
+                        "style": "danger"
+                    }
+                ]
+            }
+        ],
+        "channel": "C07LRFB3C8M",
+        "event_ts": "1725998548.581159",
+        "channel_type": "channel"
+    },
+    "type": "event_callback",
+    "event_id": "Ev07MH6R7FDE",
+    "event_time": 1725998548,
+    "authorizations": [
+        {
+            "enterprise_id": null,
+            "team_id": "T043DB835ML",
+            "user_id": "U07K4E18KJM",
+            "is_bot": true,
+            "is_enterprise_install": false
+        }
+    ],
+    "is_ext_shared_channel": false
+}

--- a/tests/golden/SlackWebhookEvent/github_with_link.golden
+++ b/tests/golden/SlackWebhookEvent/github_with_link.golden
@@ -1,0 +1,145 @@
+EventEventCallback
+    ( EventCallback
+        { eventId = EventId
+            { unEventId = "Ev07U5U3EQCV" }
+        , teamId = TeamId
+            { unTeamId = "T043DB835ML" }
+        , eventTime = MkSystemTime
+            { systemSeconds = 1730339959
+            , systemNanoseconds = 0
+            }
+        , event = EventMessage
+            ( MessageEvent
+                { blocks = Nothing
+                , channel = ConversationId
+                    { unConversationId = "C07LRFB3C8M" }
+                , text = ""
+                , channelType = Channel
+                , files = Nothing
+                , user = UserId
+                    { unUserId = "U07M725KAD7" }
+                , ts = "1730339959.644979"
+                , threadTs = Nothing
+                , appId = Just "A01BP7R4KNY"
+                , botId = Just "B07LDR01Z63"
+                , attachments = Just
+                    [ MessageAttachment
+                        { decoded = Just
+                            ( DecodedMessageAttachment
+                                { fallback = Just "[myorg/myrepo] Pull request opened by ldub"
+                                , color = Just "36a64f"
+                                , pretext = Just "Pull request opened by <https://github.com/ldub|ldub>"
+                                , authorName = Nothing
+                                , authorLink = Nothing
+                                , authorIcon = Nothing
+                                , title = Just "<https://github.com/myorg/myrepo/pull/8|#8 https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249>"
+                                , titleLink = Nothing
+                                , text = Just "this is a fake pr with a link
+
+                                  <https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249|https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249>"
+                                , fields = Nothing
+                                , imageUrl = Nothing
+                                , thumbUrl = Nothing
+                                , footer = Just "<https://github.com/myorg/myrepo|myorg/myrepo>"
+                                , footerIcon = Just "https://slack.github.com/static/img/favicon-neutral.png"
+                                , ts = Just "1730339957.0"
+                                , isMsgUnfurl = Nothing
+                                , messageBlocks = Nothing
+                                , authorId = Nothing
+                                , channelId = Nothing
+                                , channelTeam = Nothing
+                                , isAppUnfurl = Nothing
+                                , appUnfurlUrl = Nothing
+                                , fromUrl = Nothing
+                                }
+                            )
+                        , raw = Object
+                            ( fromList
+                                [
+                                    ( "actions"
+                                    , Array
+                                        [ Object
+                                            ( fromList
+                                                [
+                                                    ( "id"
+                                                    , String "1"
+                                                    )
+                                                ,
+                                                    ( "name"
+                                                    , String "comment"
+                                                    )
+                                                ,
+                                                    ( "style"
+                                                    , String ""
+                                                    )
+                                                ,
+                                                    ( "text"
+                                                    , String "Comment"
+                                                    )
+                                                ,
+                                                    ( "type"
+                                                    , String "button"
+                                                    )
+                                                ,
+                                                    ( "value"
+                                                    , String "{&amp;amp;quot;selectedOrg&amp;amp;quot;:&amp;amp;quot;myorg&amp;amp;quot;,&amp;amp;quot;selectedOrgId&amp;amp;quot;:140364112,&amp;amp;quot;selectedRepo&amp;amp;quot;:&amp;amp;quot;myrepo&amp;amp;quot;,&amp;amp;quot;selectedRepoId&amp;amp;quot;:669978765,&amp;amp;quot;number&amp;amp;quot;:8,&amp;amp;quot;htmlUrl&amp;amp;quot;:&amp;amp;quot;https://github.com/myorg/myrepo/pull/8&amp;amp;quot;,&amp;amp;quot;title&amp;amp;quot;:&amp;amp;quot;https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249&amp;amp;quot;}"
+                                                    )
+                                                ]
+                                            )
+                                        ]
+                                    )
+                                ,
+                                    ( "callback_id"
+                                    , String "pr-opened-interaction"
+                                    )
+                                ,
+                                    ( "color"
+                                    , String "36a64f"
+                                    )
+                                ,
+                                    ( "fallback"
+                                    , String "[myorg/myrepo] Pull request opened by ldub"
+                                    )
+                                ,
+                                    ( "footer"
+                                    , String "<https://github.com/myorg/myrepo|myorg/myrepo>"
+                                    )
+                                ,
+                                    ( "footer_icon"
+                                    , String "https://slack.github.com/static/img/favicon-neutral.png"
+                                    )
+                                ,
+                                    ( "id"
+                                    , Number 1.0
+                                    )
+                                ,
+                                    ( "mrkdwn_in"
+                                    , Array
+                                        [ String "text" ]
+                                    )
+                                ,
+                                    ( "pretext"
+                                    , String "Pull request opened by <https://github.com/ldub|ldub>"
+                                    )
+                                ,
+                                    ( "text"
+                                    , String "this is a fake pr with a link
+
+                                      <https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249|https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249>"
+                                    )
+                                ,
+                                    ( "title"
+                                    , String "<https://github.com/myorg/myrepo/pull/8|#8 https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249>"
+                                    )
+                                ,
+                                    ( "ts"
+                                    , Number 1.730339957e9
+                                    )
+                                ]
+                            )
+                        }
+                    ]
+                }
+            )
+        }
+    )

--- a/tests/golden/SlackWebhookEvent/github_with_link.json
+++ b/tests/golden/SlackWebhookEvent/github_with_link.json
@@ -1,0 +1,72 @@
+{
+    "token": "aaaa",
+    "team_id": "T043DB835ML",
+    "context_team_id": "T043DB835ML",
+    "context_enterprise_id": null,
+    "api_app_id": "A07JRKQPZDH",
+    "event": {
+        "user": "U07M725KAD7",
+        "type": "message",
+        "ts": "1730339959.644979",
+        "bot_id": "B07LDR01Z63",
+        "app_id": "A01BP7R4KNY",
+        "text": "",
+        "team": "T043DB835ML",
+        "bot_profile": {
+            "id": "B07LDR01Z63",
+            "deleted": false,
+            "name": "GitHub",
+            "updated": 1725998199,
+            "app_id": "A01BP7R4KNY",
+            "icons": {
+                "image_36": "https://avatars.slack-edge.com/2020-11-25/1527503386626_319578f21381f9641cd8_36.png",
+                "image_48": "https://avatars.slack-edge.com/2020-11-25/1527503386626_319578f21381f9641cd8_48.png",
+                "image_72": "https://avatars.slack-edge.com/2020-11-25/1527503386626_319578f21381f9641cd8_72.png"
+            },
+            "team_id": "T043DB835ML"
+        },
+        "attachments": [
+            {
+                "id": 1,
+                "footer_icon": "https://slack.github.com/static/img/favicon-neutral.png",
+                "ts": 1730339957,
+                "color": "36a64f",
+                "fallback": "[myorg/myrepo] Pull request opened by ldub",
+                "text": "this is a fake pr with a link\n\n<https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249|https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249>",
+                "pretext": "Pull request opened by <https://github.com/ldub|ldub>",
+                "title": "<https://github.com/myorg/myrepo/pull/8|#8 https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249>",
+                "callback_id": "pr-opened-interaction",
+                "footer": "<https://github.com/myorg/myrepo|myorg/myrepo>",
+                "mrkdwn_in": [
+                    "text"
+                ],
+                "actions": [
+                    {
+                        "id": "1",
+                        "name": "comment",
+                        "text": "Comment",
+                        "type": "button",
+                        "value": "{&amp;amp;quot;selectedOrg&amp;amp;quot;:&amp;amp;quot;myorg&amp;amp;quot;,&amp;amp;quot;selectedOrgId&amp;amp;quot;:140364112,&amp;amp;quot;selectedRepo&amp;amp;quot;:&amp;amp;quot;myrepo&amp;amp;quot;,&amp;amp;quot;selectedRepoId&amp;amp;quot;:669978765,&amp;amp;quot;number&amp;amp;quot;:8,&amp;amp;quot;htmlUrl&amp;amp;quot;:&amp;amp;quot;https://github.com/myorg/myrepo/pull/8&amp;amp;quot;,&amp;amp;quot;title&amp;amp;quot;:&amp;amp;quot;https://myteam.slack.com/archives/C07KTH1T4CQ/p1730339894629249&amp;amp;quot;}",
+                        "style": ""
+                    }
+                ]
+            }
+        ],
+        "channel": "C07LRFB3C8M",
+        "event_ts": "1730339959.644979",
+        "channel_type": "channel"
+    },
+    "type": "event_callback",
+    "event_id": "Ev07U5U3EQCV",
+    "event_time": 1730339959,
+    "authorizations": [
+        {
+            "enterprise_id": null,
+            "team_id": "T043DB835ML",
+            "user_id": "U07K4E18KJM",
+            "is_bot": true,
+            "is_enterprise_install": false
+        }
+    ],
+    "is_ext_shared_channel": false
+}

--- a/tests/golden/SlackWebhookEvent/non_spec_attachment.golden
+++ b/tests/golden/SlackWebhookEvent/non_spec_attachment.golden
@@ -1,0 +1,99 @@
+EventEventCallback
+    ( EventCallback
+        { eventId = EventId
+            { unEventId = "Ev07MH6R7FDE" }
+        , teamId = TeamId
+            { unTeamId = "T043DB835ML" }
+        , eventTime = MkSystemTime
+            { systemSeconds = 1725998548
+            , systemNanoseconds = 0
+            }
+        , event = EventMessage
+            ( MessageEvent
+                { blocks = Nothing
+                , channel = ConversationId
+                    { unConversationId = "C07LRFB3C8M" }
+                , text = ""
+                , channelType = Channel
+                , files = Nothing
+                , user = UserId
+                    { unUserId = "U07M725KAD7" }
+                , ts = "1725998548.581159"
+                , threadTs = Nothing
+                , appId = Just "A01BP7R4KNY"
+                , botId = Just "B07LDR01Z63"
+                , attachments = Just
+                    [ MessageAttachment
+                        { decoded = Just
+                            ( DecodedMessageAttachment
+                                { fallback = Nothing
+                                , color = Nothing
+                                , pretext = Nothing
+                                , authorName = Nothing
+                                , authorLink = Nothing
+                                , authorIcon = Nothing
+                                , title = Nothing
+                                , titleLink = Nothing
+                                , text = Nothing
+                                , fields = Nothing
+                                , imageUrl = Nothing
+                                , thumbUrl = Nothing
+                                , footer = Nothing
+                                , footerIcon = Nothing
+                                , ts = Nothing
+                                , isMsgUnfurl = Nothing
+                                , messageBlocks = Nothing
+                                , authorId = Nothing
+                                , channelId = Nothing
+                                , channelTeam = Nothing
+                                , isAppUnfurl = Nothing
+                                , appUnfurlUrl = Nothing
+                                , fromUrl = Nothing
+                                }
+                            )
+                        , raw = Object
+                            ( fromList
+                                [
+                                    ( "any"
+                                    , Object
+                                        ( fromList
+                                            [
+                                                ( "specific"
+                                                , String "format"
+                                                )
+                                            ]
+                                        )
+                                    )
+                                ,
+                                    ( "but"
+                                    , String "It should still parse fine."
+                                    )
+                                ,
+                                    ( "does"
+                                    , String "not"
+                                    )
+                                ,
+                                    ( "follow"
+                                    , Number 0.0
+                                    )
+                                ,
+                                    ( "or"
+                                    , Array
+                                        [ String "spec" ]
+                                    )
+                                ,
+                                    ( "that"
+                                    , String "Slack has ever published."
+                                    )
+                                ,
+                                    ( "this"
+                                    , String "attachments"
+                                    )
+                                ]
+                            )
+                        }
+                    ]
+                }
+            )
+        }
+    )

--- a/tests/golden/SlackWebhookEvent/non_spec_attachment.json
+++ b/tests/golden/SlackWebhookEvent/non_spec_attachment.json
@@ -1,0 +1,58 @@
+{
+    "token": "aaaa",
+    "team_id": "T043DB835ML",
+    "context_team_id": "T043DB835ML",
+    "context_enterprise_id": null,
+    "api_app_id": "A07JRKQPZDH",
+    "event": {
+        "user": "U07M725KAD7",
+        "type": "message",
+        "ts": "1725998548.581159",
+        "bot_id": "B07LDR01Z63",
+        "app_id": "A01BP7R4KNY",
+        "text": "",
+        "team": "T043DB835ML",
+        "bot_profile": {
+            "id": "B07LDR01Z63",
+            "deleted": false,
+            "name": "GitHub",
+            "updated": 1725998199,
+            "app_id": "A01BP7R4KNY",
+            "icons": {
+                "image_36": "https://avatars.slack-edge.com/2020-11-25/1527503386626_319578f21381f9641cd8_36.png",
+                "image_48": "https://avatars.slack-edge.com/2020-11-25/1527503386626_319578f21381f9641cd8_48.png",
+                "image_72": "https://avatars.slack-edge.com/2020-11-25/1527503386626_319578f21381f9641cd8_72.png"
+            },
+            "team_id": "T043DB835ML"
+        },
+        "attachments": [
+            {
+                "this": "attachments",
+                "does": "not",
+                "follow": 0,
+                "any": {
+                    "specific": "format"
+                },
+                "or": ["spec"],
+                "that": "Slack has ever published.",
+                "but": "It should still parse fine."
+            }
+        ],
+        "channel": "C07LRFB3C8M",
+        "event_ts": "1725998548.581159",
+        "channel_type": "channel"
+    },
+    "type": "event_callback",
+    "event_id": "Ev07MH6R7FDE",
+    "event_time": 1725998548,
+    "authorizations": [
+        {
+            "enterprise_id": null,
+            "team_id": "T043DB835ML",
+            "user_id": "U07K4E18KJM",
+            "is_bot": true,
+            "is_enterprise_install": false
+        }
+    ],
+    "is_ext_shared_channel": false
+}

--- a/tests/golden/SlackWebhookEvent/share_with_message.golden
+++ b/tests/golden/SlackWebhookEvent/share_with_message.golden
@@ -39,64 +39,212 @@ EventEventCallback
                 , botId = Nothing
                 , attachments = Just
                     [ MessageAttachment
-                        { fallback = Just "[August 29th, 2024 2:26 PM] lev: this will be shared with a message"
-                        , color = Just "D0D0D0"
-                        , pretext = Nothing
-                        , authorName = Just "lev"
-                        , authorLink = Just "https://myworkspace.slack.com/team/U05JAA9EN4T"
-                        , authorIcon = Just "https://avatars.slack-edge.com/2023-07-22/5607926127815_66b9d49327ec16a887e5_48.png"
-                        , title = Nothing
-                        , titleLink = Nothing
-                        , text = Just "this will be shared with a message"
-                        , fields = Nothing
-                        , imageUrl = Nothing
-                        , thumbUrl = Nothing
-                        , footer = Just "Slack Conversation"
-                        , footerIcon = Nothing
-                        , ts = Just "1724966776.474889"
-                        , isMsgUnfurl = Just True
-                        , messageBlocks = Just
-                            [ AttachmentMessageBlock
-                                { team = TeamId
-                                    { unTeamId = "T043DB835ML" }
-                                , channel = ConversationId
-                                    { unConversationId = "C07KTH1T4CQ" }
-                                , ts = "1724966776.474889"
-                                , message = AttachmentMessageBlockMessage
-                                    { blocks =
-                                        [ RichText
-                                            { blockId = Just
-                                                ( NonEmptyText "BXn1o" )
-                                            , elements =
-                                                [ RichTextSectionItemRichText
-                                                    [ RichItemText "this will be shared with a message"
-                                                        ( RichStyle
-                                                            { rsBold = False
-                                                            , rsItalic = False
-                                                            }
-                                                        )
-                                                    ]
+                        { decoded = Just
+                            ( DecodedMessageAttachment
+                                { fallback = Just "[August 29th, 2024 2:26 PM] lev: this will be shared with a message"
+                                , color = Just "D0D0D0"
+                                , pretext = Nothing
+                                , authorName = Just "lev"
+                                , authorLink = Just "https://myworkspace.slack.com/team/U05JAA9EN4T"
+                                , authorIcon = Just "https://avatars.slack-edge.com/2023-07-22/5607926127815_66b9d49327ec16a887e5_48.png"
+                                , title = Nothing
+                                , titleLink = Nothing
+                                , text = Just "this will be shared with a message"
+                                , fields = Nothing
+                                , imageUrl = Nothing
+                                , thumbUrl = Nothing
+                                , footer = Just "Slack Conversation"
+                                , footerIcon = Nothing
+                                , ts = Just "1724966776.474889"
+                                , isMsgUnfurl = Just True
+                                , messageBlocks = Just
+                                    [ AttachmentMessageBlock
+                                        { team = TeamId
+                                            { unTeamId = "T043DB835ML" }
+                                        , channel = ConversationId
+                                            { unConversationId = "C07KTH1T4CQ" }
+                                        , ts = "1724966776.474889"
+                                        , message = AttachmentMessageBlockMessage
+                                            { blocks =
+                                                [ RichText
+                                                    { blockId = Just
+                                                        ( NonEmptyText "BXn1o" )
+                                                    , elements =
+                                                        [ RichTextSectionItemRichText
+                                                            [ RichItemText "this will be shared with a message"
+                                                                ( RichStyle
+                                                                    { rsBold = False
+                                                                    , rsItalic = False
+                                                                    }
+                                                                )
+                                                            ]
+                                                        ]
+                                                    }
                                                 ]
                                             }
-                                        ]
-                                    }
+                                        }
+                                    ]
+                                , authorId = Just
+                                    ( UserId
+                                        { unUserId = "U05JAA9EN4T" }
+                                    )
+                                , channelId = Just
+                                    ( ConversationId
+                                        { unConversationId = "C07KTH1T4CQ" }
+                                    )
+                                , channelTeam = Just
+                                    ( TeamId
+                                        { unTeamId = "T043DB835ML" }
+                                    )
+                                , isAppUnfurl = Nothing
+                                , appUnfurlUrl = Nothing
+                                , fromUrl = Just "https://myworkspace.slack.com/archives/C07KTH1T4CQ/p1724966776474889"
                                 }
-                            ]
-                        , authorId = Just
-                            ( UserId
-                                { unUserId = "U05JAA9EN4T" }
                             )
-                        , channelId = Just
-                            ( ConversationId
-                                { unConversationId = "C07KTH1T4CQ" }
+                        , raw = Object
+                            ( fromList
+                                [
+                                    ( "author_icon"
+                                    , String "https://avatars.slack-edge.com/2023-07-22/5607926127815_66b9d49327ec16a887e5_48.png"
+                                    )
+                                ,
+                                    ( "author_id"
+                                    , String "U05JAA9EN4T"
+                                    )
+                                ,
+                                    ( "author_link"
+                                    , String "https://myworkspace.slack.com/team/U05JAA9EN4T"
+                                    )
+                                ,
+                                    ( "author_name"
+                                    , String "lev"
+                                    )
+                                ,
+                                    ( "author_subname"
+                                    , String "lev"
+                                    )
+                                ,
+                                    ( "channel_id"
+                                    , String "C07KTH1T4CQ"
+                                    )
+                                ,
+                                    ( "channel_team"
+                                    , String "T043DB835ML"
+                                    )
+                                ,
+                                    ( "color"
+                                    , String "D0D0D0"
+                                    )
+                                ,
+                                    ( "fallback"
+                                    , String "[August 29th, 2024 2:26 PM] lev: this will be shared with a message"
+                                    )
+                                ,
+                                    ( "footer"
+                                    , String "Slack Conversation"
+                                    )
+                                ,
+                                    ( "from_url"
+                                    , String "https://myworkspace.slack.com/archives/C07KTH1T4CQ/p1724966776474889"
+                                    )
+                                ,
+                                    ( "is_msg_unfurl"
+                                    , Bool True
+                                    )
+                                ,
+                                    ( "is_share"
+                                    , Bool True
+                                    )
+                                ,
+                                    ( "message_blocks"
+                                    , Array
+                                        [ Object
+                                            ( fromList
+                                                [
+                                                    ( "channel"
+                                                    , String "C07KTH1T4CQ"
+                                                    )
+                                                ,
+                                                    ( "message"
+                                                    , Object
+                                                        ( fromList
+                                                            [
+                                                                ( "blocks"
+                                                                , Array
+                                                                    [ Object
+                                                                        ( fromList
+                                                                            [
+                                                                                ( "block_id"
+                                                                                , String "BXn1o"
+                                                                                )
+                                                                            ,
+                                                                                ( "elements"
+                                                                                , Array
+                                                                                    [ Object
+                                                                                        ( fromList
+                                                                                            [
+                                                                                                ( "elements"
+                                                                                                , Array
+                                                                                                    [ Object
+                                                                                                        ( fromList
+                                                                                                            [
+                                                                                                                ( "text"
+                                                                                                                , String "this will be shared with a message"
+                                                                                                                )
+                                                                                                            ,
+                                                                                                                ( "type"
+                                                                                                                , String "text"
+                                                                                                                )
+                                                                                                            ]
+                                                                                                        )
+                                                                                                    ]
+                                                                                                )
+                                                                                            ,
+                                                                                                ( "type"
+                                                                                                , String "rich_text_section"
+                                                                                                )
+                                                                                            ]
+                                                                                        )
+                                                                                    ]
+                                                                                )
+                                                                            ,
+                                                                                ( "type"
+                                                                                , String "rich_text"
+                                                                                )
+                                                                            ]
+                                                                        )
+                                                                    ]
+                                                                )
+                                                            ]
+                                                        )
+                                                    )
+                                                ,
+                                                    ( "team"
+                                                    , String "T043DB835ML"
+                                                    )
+                                                ,
+                                                    ( "ts"
+                                                    , String "1724966776.474889"
+                                                    )
+                                                ]
+                                            )
+                                        ]
+                                    )
+                                ,
+                                    ( "mrkdwn_in"
+                                    , Array
+                                        [ String "text" ]
+                                    )
+                                ,
+                                    ( "text"
+                                    , String "this will be shared with a message"
+                                    )
+                                ,
+                                    ( "ts"
+                                    , String "1724966776.474889"
+                                    )
+                                ]
                             )
-                        , channelTeam = Just
-                            ( TeamId
-                                { unTeamId = "T043DB835ML" }
-                            )
-                        , isAppUnfurl = Nothing
-                        , appUnfurlUrl = Nothing
-                        , fromUrl = Just "https://myworkspace.slack.com/archives/C07KTH1T4CQ/p1724966776474889"
                         }
                     ]
                 }

--- a/tests/golden/SlackWebhookEvent/share_without_message.golden
+++ b/tests/golden/SlackWebhookEvent/share_without_message.golden
@@ -24,64 +24,216 @@ EventEventCallback
                 , botId = Nothing
                 , attachments = Just
                     [ MessageAttachment
-                        { fallback = Just "[October 12th, 2022 4:04 PM] jadel: blahblahblahblahblah"
-                        , color = Just "D0D0D0"
-                        , pretext = Nothing
-                        , authorName = Just "jadel"
-                        , authorLink = Just "https://jadeapptesting.slack.com/team/U043H11ES4V"
-                        , authorIcon = Just "https://secure.gravatar.com/avatar/dcd5bc53dcfaca62ddc3f5726d07ba13.jpg?s=48&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0019-48.png"
-                        , title = Nothing
-                        , titleLink = Nothing
-                        , text = Just "blahblahblahblahblah"
-                        , fields = Nothing
-                        , imageUrl = Nothing
-                        , thumbUrl = Nothing
-                        , footer = Just "Posted in #testing-slack-app"
-                        , footerIcon = Nothing
-                        , ts = Just "1665615886.364019"
-                        , isMsgUnfurl = Just True
-                        , messageBlocks = Just
-                            [ AttachmentMessageBlock
-                                { team = TeamId
-                                    { unTeamId = "T043DB835ML" }
-                                , channel = ConversationId
-                                    { unConversationId = "C043KSKGJUB" }
-                                , ts = "1665615886.364019"
-                                , message = AttachmentMessageBlockMessage
-                                    { blocks =
-                                        [ RichText
-                                            { blockId = Just
-                                                ( NonEmptyText "TNHa4" )
-                                            , elements =
-                                                [ RichTextSectionItemRichText
-                                                    [ RichItemText "blahblahblahblahblah"
-                                                        ( RichStyle
-                                                            { rsBold = False
-                                                            , rsItalic = False
-                                                            }
-                                                        )
-                                                    ]
+                        { decoded = Just
+                            ( DecodedMessageAttachment
+                                { fallback = Just "[October 12th, 2022 4:04 PM] jadel: blahblahblahblahblah"
+                                , color = Just "D0D0D0"
+                                , pretext = Nothing
+                                , authorName = Just "jadel"
+                                , authorLink = Just "https://jadeapptesting.slack.com/team/U043H11ES4V"
+                                , authorIcon = Just "https://secure.gravatar.com/avatar/dcd5bc53dcfaca62ddc3f5726d07ba13.jpg?s=48&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0019-48.png"
+                                , title = Nothing
+                                , titleLink = Nothing
+                                , text = Just "blahblahblahblahblah"
+                                , fields = Nothing
+                                , imageUrl = Nothing
+                                , thumbUrl = Nothing
+                                , footer = Just "Posted in #testing-slack-app"
+                                , footerIcon = Nothing
+                                , ts = Just "1665615886.364019"
+                                , isMsgUnfurl = Just True
+                                , messageBlocks = Just
+                                    [ AttachmentMessageBlock
+                                        { team = TeamId
+                                            { unTeamId = "T043DB835ML" }
+                                        , channel = ConversationId
+                                            { unConversationId = "C043KSKGJUB" }
+                                        , ts = "1665615886.364019"
+                                        , message = AttachmentMessageBlockMessage
+                                            { blocks =
+                                                [ RichText
+                                                    { blockId = Just
+                                                        ( NonEmptyText "TNHa4" )
+                                                    , elements =
+                                                        [ RichTextSectionItemRichText
+                                                            [ RichItemText "blahblahblahblahblah"
+                                                                ( RichStyle
+                                                                    { rsBold = False
+                                                                    , rsItalic = False
+                                                                    }
+                                                                )
+                                                            ]
+                                                        ]
+                                                    }
                                                 ]
                                             }
-                                        ]
-                                    }
+                                        }
+                                    ]
+                                , authorId = Just
+                                    ( UserId
+                                        { unUserId = "U043H11ES4V" }
+                                    )
+                                , channelId = Just
+                                    ( ConversationId
+                                        { unConversationId = "C043KSKGJUB" }
+                                    )
+                                , channelTeam = Just
+                                    ( TeamId
+                                        { unTeamId = "T043DB835ML" }
+                                    )
+                                , isAppUnfurl = Nothing
+                                , appUnfurlUrl = Nothing
+                                , fromUrl = Just "https://jadeapptesting.slack.com/archives/C043KSKGJUB/p1665615886364019"
                                 }
-                            ]
-                        , authorId = Just
-                            ( UserId
-                                { unUserId = "U043H11ES4V" }
                             )
-                        , channelId = Just
-                            ( ConversationId
-                                { unConversationId = "C043KSKGJUB" }
+                        , raw = Object
+                            ( fromList
+                                [
+                                    ( "author_icon"
+                                    , String "https://secure.gravatar.com/avatar/dcd5bc53dcfaca62ddc3f5726d07ba13.jpg?s=48&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0019-48.png"
+                                    )
+                                ,
+                                    ( "author_id"
+                                    , String "U043H11ES4V"
+                                    )
+                                ,
+                                    ( "author_link"
+                                    , String "https://jadeapptesting.slack.com/team/U043H11ES4V"
+                                    )
+                                ,
+                                    ( "author_name"
+                                    , String "jadel"
+                                    )
+                                ,
+                                    ( "author_subname"
+                                    , String "jadel"
+                                    )
+                                ,
+                                    ( "channel_id"
+                                    , String "C043KSKGJUB"
+                                    )
+                                ,
+                                    ( "channel_name"
+                                    , String "testing-slack-app"
+                                    )
+                                ,
+                                    ( "channel_team"
+                                    , String "T043DB835ML"
+                                    )
+                                ,
+                                    ( "color"
+                                    , String "D0D0D0"
+                                    )
+                                ,
+                                    ( "fallback"
+                                    , String "[October 12th, 2022 4:04 PM] jadel: blahblahblahblahblah"
+                                    )
+                                ,
+                                    ( "footer"
+                                    , String "Posted in #testing-slack-app"
+                                    )
+                                ,
+                                    ( "from_url"
+                                    , String "https://jadeapptesting.slack.com/archives/C043KSKGJUB/p1665615886364019"
+                                    )
+                                ,
+                                    ( "is_msg_unfurl"
+                                    , Bool True
+                                    )
+                                ,
+                                    ( "is_share"
+                                    , Bool True
+                                    )
+                                ,
+                                    ( "message_blocks"
+                                    , Array
+                                        [ Object
+                                            ( fromList
+                                                [
+                                                    ( "channel"
+                                                    , String "C043KSKGJUB"
+                                                    )
+                                                ,
+                                                    ( "message"
+                                                    , Object
+                                                        ( fromList
+                                                            [
+                                                                ( "blocks"
+                                                                , Array
+                                                                    [ Object
+                                                                        ( fromList
+                                                                            [
+                                                                                ( "block_id"
+                                                                                , String "TNHa4"
+                                                                                )
+                                                                            ,
+                                                                                ( "elements"
+                                                                                , Array
+                                                                                    [ Object
+                                                                                        ( fromList
+                                                                                            [
+                                                                                                ( "elements"
+                                                                                                , Array
+                                                                                                    [ Object
+                                                                                                        ( fromList
+                                                                                                            [
+                                                                                                                ( "text"
+                                                                                                                , String "blahblahblahblahblah"
+                                                                                                                )
+                                                                                                            ,
+                                                                                                                ( "type"
+                                                                                                                , String "text"
+                                                                                                                )
+                                                                                                            ]
+                                                                                                        )
+                                                                                                    ]
+                                                                                                )
+                                                                                            ,
+                                                                                                ( "type"
+                                                                                                , String "rich_text_section"
+                                                                                                )
+                                                                                            ]
+                                                                                        )
+                                                                                    ]
+                                                                                )
+                                                                            ,
+                                                                                ( "type"
+                                                                                , String "rich_text"
+                                                                                )
+                                                                            ]
+                                                                        )
+                                                                    ]
+                                                                )
+                                                            ]
+                                                        )
+                                                    )
+                                                ,
+                                                    ( "team"
+                                                    , String "T043DB835ML"
+                                                    )
+                                                ,
+                                                    ( "ts"
+                                                    , String "1665615886.364019"
+                                                    )
+                                                ]
+                                            )
+                                        ]
+                                    )
+                                ,
+                                    ( "mrkdwn_in"
+                                    , Array
+                                        [ String "text" ]
+                                    )
+                                ,
+                                    ( "text"
+                                    , String "blahblahblahblahblah"
+                                    )
+                                ,
+                                    ( "ts"
+                                    , String "1665615886.364019"
+                                    )
+                                ]
                             )
-                        , channelTeam = Just
-                            ( TeamId
-                                { unTeamId = "T043DB835ML" }
-                            )
-                        , isAppUnfurl = Nothing
-                        , appUnfurlUrl = Nothing
-                        , fromUrl = Just "https://jadeapptesting.slack.com/archives/C043KSKGJUB/p1665615886364019"
                         }
                     ]
                 }


### PR DESCRIPTION
Having read a lot of Slack documentation and operated v2.0.0.3 in production for a bit, I now understand that the Slack message attachment field is poorly standardized. None of the fields are required and there are different versions of the attachments api over the years that are all supported in this one field.

To make apps that look at attachments, chance are, you're going to need to look at the raw json value. So I've edited slack-web to try to decode the attachment based on documented schema (and ported from Slack's own open source javascript sdks) but then also pass the raw json value to clients.

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)