### PR TITLE
fix for missing `previous_names` in conversation

### DIFF
--- a/src/Web/Slack/Conversation.hs
+++ b/src/Web/Slack/Conversation.hs
@@ -126,7 +126,7 @@ data ChannelConversation = ChannelConversation
   -- ^ Absent from @users.conversations@ response
   , channelTopic :: Topic
   , channelPurpose :: Purpose
-  , channelPreviousNames :: [Text]
+  , channelPreviousNames :: Maybe [Text]
   , channelNumMembers :: Maybe Integer
   -- ^ Absent from @conversations.join@ response
   }

--- a/tests/Web/Slack/ConversationSpec.hs
+++ b/tests/Web/Slack/ConversationSpec.hs
@@ -114,6 +114,7 @@ spec = describe "ToJSON and FromJSON for Conversation" $ do
 
   describe "Golden tests" $ do
     mapM_ (oneGoldenTestDecode @Conversation) ["shared_channel"]
+    mapM_ (oneGoldenTestDecode @Conversation) ["no_previous_names"]
     mapM_ (oneGoldenTestDecode @InfoRsp) ["general"]
     mapM_ (oneGoldenTestDecode @JoinRsp) ["test"]
     mapM_ (oneGoldenTestDecode @MembersRsp) ["test"]

--- a/tests/golden/Conversation/no_previous_names.golden
+++ b/tests/golden/Conversation/no_previous_names.golden
@@ -26,7 +26,7 @@ Channel
             , purposeCreator = ""
             , purposeLastSet = 0
             }
-        , channelPreviousNames = Just []
+        , channelPreviousNames = Nothing
         , channelNumMembers = Just 12
         }
     )

--- a/tests/golden/Conversation/no_previous_names.json
+++ b/tests/golden/Conversation/no_previous_names.json
@@ -1,0 +1,36 @@
+{
+  "id": "C0000000000",
+  "name": "shared-channel",
+  "is_channel": true,
+  "is_group": false,
+  "is_im": false,
+  "is_mpim": false,
+  "is_private": false,
+  "created": 1667519517,
+  "is_archived": false,
+  "is_general": false,
+  "unlinked": 0,
+  "name_normalized": "shared-channel",
+  "is_shared": true,
+  "is_org_shared": false,
+  "is_pending_ext_shared": false,
+  "pending_shared": [],
+  "context_team_id": "TAAAAAAAA",
+  "parent_conversation": null,
+  "creator": "UAAAAAAAA",
+  "is_ext_shared": true,
+  "pending_connected_team_ids": [],
+  "conversation_host_id": "TAAAAAAAA",
+  "is_member": false,
+  "topic": {
+    "value": "",
+    "creator": "",
+    "last_set": 0
+  },
+  "purpose": {
+    "value": "",
+    "creator": "",
+    "last_set": 0
+  },
+  "num_members": 12
+}

--- a/tests/golden/InfoRsp/general.golden
+++ b/tests/golden/InfoRsp/general.golden
@@ -30,7 +30,7 @@ InfoRsp
                 , purposeCreator = "U043H11ES4V"
                 , purposeLastSet = 1663890553
                 }
-            , channelPreviousNames = []
+            , channelPreviousNames = Just []
             , channelNumMembers = Nothing
             }
         )

--- a/tests/golden/JoinRsp/test.golden
+++ b/tests/golden/JoinRsp/test.golden
@@ -30,7 +30,7 @@ JoinRsp
                 , purposeCreator = ""
                 , purposeLastSet = 0
                 }
-            , channelPreviousNames = []
+            , channelPreviousNames = Just []
             , channelNumMembers = Nothing
             }
         )

--- a/tests/golden/UsersConversationsResponse/im_and_channels.golden
+++ b/tests/golden/UsersConversationsResponse/im_and_channels.golden
@@ -31,7 +31,7 @@ UsersConversationsResponse
                     , purposeCreator = "U043H11ES4V"
                     , purposeLastSet = 1663890553
                     }
-                , channelPreviousNames = []
+                , channelPreviousNames = Just []
                 , channelNumMembers = Nothing
                 }
             )
@@ -66,7 +66,7 @@ UsersConversationsResponse
                     , purposeCreator = ""
                     , purposeLastSet = 0
                     }
-                , channelPreviousNames = []
+                , channelPreviousNames = Just []
                 , channelNumMembers = Nothing
                 }
             )


### PR DESCRIPTION
Sometimes, Slack Web API does not return `previous_names` for conversation, and requests fail with this kind of error:

```
user error (ServantError (DecodeFailure "Error in $.channels[0]: When parsing the record ChannelConversation of type Web.Slack.Conversation.ChannelConversation the key previous_names was not present." (Response {responseStatusCode = Status {statusCode = 200, statusMessage = "OK"}, responseHeaders = fromList [("date","Tue, 04 Nov 2025 07:54:59 GMT"),("server","Apache"),("vary","Accept-Encoding"),("x-slack-req-id","22d2092ddc4f20a01ec0163979b4d2e7"),("x-content-type-options","nosniff"),("x-xss-protection","0"),("pragma","no-cache"),("cache-control","private, no-cache, no-store, must-revalidate"),("expires","Sat, 26 Jul 1997 05:00:00 GMT"),("content-type","application/json; charset=utf-8"),("x-accepted-oauth-scopes","channels:read,groups:read,mpim:read,im:read,read"),("x-oauth-scopes","chat:write,groups:read,channels:read"),("access-control-expose-headers","x-slack-req-id, retry-after"),("access-control-allow-headers","slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags"),("strict-transport-security","max-age=31536000; includeSubDomains; preload"),("referrer-policy","no-referrer"),("x-slack-unique-id","XXXXXXXXXXXXXXXXXXXXXXXXXXX"),("x-slack-backend","r"),("access-control-allow-origin","*"),("via","1.1 slack-prod.tinyspeck.com, envoy-www-iad-tsmdntwm,envoy-edge-canary-sin-mzuhckfu"),("content-encoding","gzip"),("content-length","381"),("x-envoy-attempt-count","1"),("x-envoy-upstream-service-time","301"),("x-backend","main_normal main_canary_with_overflow main_control_with_overflow"),("x-server","slack-www-hhvm-main-iad-qqux"),("x-slack-shared-secret-outcome","no-match"),("x-edge-backend","envoy-www"),("timing-allow-origin","*"),("alt-svc","h3=\":443\"; ma=10800, h3-29=\":443\"; ma=10800, quic=\":443\"; ma=10800"),("x-slack-edge-shared-secret-outcome","no-match")], responseHttpVersion = HTTP/1.1, responseBody = "{\"ok\":true,\"channels\":[{\"id\":\"C0000000000\",\"created\":1761988686,\"creator\":\"UAAAAAAAA\",\"is_org_shared\":false,\"is_im\":false,\"context_team_id\":\"TAAAAAAAA\",\"updated\":1761988686476,\"name\":\"bot-test\",\"name_normalized\":\"bot-test\",\"is_channel\":true,\"is_group\":false,\"is_mpim\":false,\"is_private\":true,\"is_archived\":false,\"is_general\":false,\"is_shared\":false,\"is_ext_shared\":false,\"unlinked\":0,\"is_pending_ext_shared\":false,\"pending_shared\":[],\"parent_conversation\":null,\"purpose\":{\"value\":\"\",\"creator\":\"\",\"last_set\":0},\"topic\":{\"value\":\"\",\"creator\":\"\",\"last_set\":0},\"shared_team_ids\":[\"TAAAAAAAA\"],\"pending_connected_team_ids\":[],\"is_member\":true,\"num_members\":2}],\"response_metadata\":{\"next_cursor\":\"ZXh0ZXJuYWw6QzA3OEYzODBXVFY=\"}}"})))
```

This PR goes for minimal diff, but the change is breaking. Another, proper way to fix this would be, in this case, to interpret missing `previous_names` into empty list, but this would require writing custom JSON parser for Conversation. Tell me what you think.

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)