### PR TITLE
Add support for message_deleted event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.3.0 (2025-09-15)
+* [#156](https://github.com/MercuryTechnologies/slack-web/pull/156)
+  Implement `message_deleted` event.
+
 # 2.2.2.0 (2025-09-15)
 * [#153](https://github.com/MercuryTechnologies/slack-web/pull/153)
   Implement `channel_shared` and `channel_unshared` events.

--- a/tests/Web/Slack/Experimental/Events/TypesSpec.hs
+++ b/tests/Web/Slack/Experimental/Events/TypesSpec.hs
@@ -12,6 +12,7 @@ spec = describe "Types for Slack events" do
         (oneGoldenTestDecode @SlackWebhookEvent)
         [ "messageExample"
         , "messageChange"
+        , "message_deleted"
         , "message_rich_text"
         , "message_file_share"
         , "message_file_share_slack_connect"

--- a/tests/golden/SlackWebhookEvent/message_deleted.golden
+++ b/tests/golden/SlackWebhookEvent/message_deleted.golden
@@ -1,0 +1,20 @@
+EventEventCallback
+    ( EventCallback
+        { eventId = EventId
+            { unEventId = "Ev043QRVT9FE" }
+        , teamId = TeamId
+            { unTeamId = "T043DB835ML" }
+        , eventTime = MkSystemTime
+            { systemSeconds = 1663969383
+            , systemNanoseconds = 0
+            }
+        , event = EventMessageDeleted
+            ( MessageDeletedEvent
+                { channel = ConversationId
+                    { unConversationId = "C043YJGBY49" }
+                , ts = "1663969383.001500"
+                , deletedTs = "1663966382.046509"
+                }
+            )
+        }
+    )

--- a/tests/golden/SlackWebhookEvent/message_deleted.json
+++ b/tests/golden/SlackWebhookEvent/message_deleted.json
@@ -1,0 +1,37 @@
+{
+  "token": "aaaa",
+  "team_id": "T043DB835ML",
+  "api_app_id": "A0442TUPHGR",
+  "event": {
+    "type": "message",
+    "subtype": "message_deleted",
+    "hidden": true,
+    "channel": "C043YJGBY49",
+    "previous_message": {
+      "client_msg_id": "de349a9f-62a4-4293-b64d-701a1f566e8a",
+      "type": "message",
+      "text": "This message will be deleted",
+      "user": "U043H11ES4V",
+      "ts": "1663966382.046509",
+      "team": "T043DB835ML"
+    },
+    "deleted_ts": "1663966382.046509",
+    "ts": "1663969383.001500",
+    "event_ts": "1663969383.001500",
+    "channel_type": "channel"
+  },
+  "type": "event_callback",
+  "event_id": "Ev043QRVT9FE",
+  "event_time": 1663969383,
+  "authorizations": [
+    {
+      "enterprise_id": null,
+      "team_id": "T043DB835ML",
+      "user_id": "U0442US8QGH",
+      "is_bot": true,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": "aaaa"
+}


### PR DESCRIPTION
* Implement [message_deleted](https://docs.slack.dev/reference/events/message/message_deleted/) event.
* Add missing @ since declarations for previous channel shared/unshared events from #153 