### PR TITLE
Add userIsBot field to User type

### DIFF
--- a/src/Web/Slack/User.hs
+++ b/src/Web/Slack/User.hs
@@ -55,6 +55,7 @@ data User = User
   , userIsPrimaryOwner :: Maybe Bool
   , userIsRestricted :: Maybe Bool
   , userIsUltraRestricted :: Maybe Bool
+  , userIsBot :: Maybe Bool
   , userUpdated :: POSIXTime
   }
   deriving stock (Eq, Generic, Show)


### PR DESCRIPTION
## Summary
- Adds `userIsBot :: Maybe Bool` to the `User` record type in `Web.Slack.User`
- The Slack API returns `is_bot` on user objects (from `users.list`, `users.info`, etc.) but the library was not decoding it
- Uses `Maybe Bool` for backwards compatibility, consistent with the other boolean fields (`userIsAdmin`, `userIsOwner`, etc.)

## Motivation
We need to filter bot users from channel member lists in MWB's Good Morning bot. Without `is_bot` on the `User` type, there's no reliable way to distinguish bots from humans using the library.

## Test plan
- [x] Library builds cleanly
- [x] All 82 existing tests pass (the `deriveFromJSON` TH handles the new field automatically)
- [x] Field uses `Maybe Bool` so existing JSON without `is_bot` deserializes as `Nothing`

Made with [Cursor](https://cursor.com)