### PR TITLE
Add golden test for User/ListRsp with is_bot field

### DIFF
--- a/tests/Web/Slack/UserSpec.hs
+++ b/tests/Web/Slack/UserSpec.hs
@@ -1,0 +1,13 @@
+module Web.Slack.UserSpec (spec) where
+
+import JSONGolden
+import TestImport
+import Web.Slack.User (ListRsp)
+
+-- Fixture modeled on the example response at
+-- https://api.slack.com/methods/users.list#examples
+spec :: Spec
+spec = describe "User methods" do
+  describe "users.list" do
+    describe "Response FromJSON" do
+      mapM_ (oneGoldenTestDecode @ListRsp) ["with_bots"]

--- a/tests/golden/ListRsp/with_bots.golden
+++ b/tests/golden/ListRsp/with_bots.golden
@@ -1,0 +1,87 @@
+ListRsp
+    { listRspMembers =
+        [ User
+            { userId = UserId
+                { unUserId = "U023BECGF" }
+            , userName = "alice"
+            , userDeleted = False
+            , userColor = Just
+                ( Color
+                    { unColor = "9f69e7" }
+                )
+            , userProfile = Just
+                ( Profile
+                    { profileAvatarHash = Just "ge3b51ca72de"
+                    , profileStatusText = Just "Working remotely"
+                    , profileStatusEmoji = Just
+                        ( Emoji
+                            { unEmoji = ":house_with_garden:" }
+                        )
+                    , profileRealName = Just "Alice Johnson"
+                    , profileDisplayName = Just "alice"
+                    , profileRealNameNormalized = Just "Alice Johnson"
+                    , profileDisplayNameNormalized = Just "alice"
+                    , profileEmail = Just "alice@example.com"
+                    , profileImage_24 = "https://example.com/24.png"
+                    , profileImage_32 = "https://example.com/32.png"
+                    , profileImage_48 = "https://example.com/48.png"
+                    , profileImage_72 = "https://example.com/72.png"
+                    , profileImage_192 = "https://example.com/192.png"
+                    , profileImage_512 = "https://example.com/512.png"
+                    , profileTeam = Just "T012AB3C4"
+                    }
+                )
+            , userIsAdmin = Just True
+            , userIsOwner = Just False
+            , userIsPrimaryOwner = Just False
+            , userIsRestricted = Just False
+            , userIsUltraRestricted = Just False
+            , userIsBot = Just False
+            , userUpdated = 1502138686s
+            }
+        , User
+            { userId = UserId
+                { unUserId = "U061F7AUR" }
+            , userName = "good-morning-bot"
+            , userDeleted = False
+            , userColor = Just
+                ( Color
+                    { unColor = "e7392d" }
+                )
+            , userProfile = Nothing
+            , userIsAdmin = Just False
+            , userIsOwner = Just False
+            , userIsPrimaryOwner = Just False
+            , userIsRestricted = Just False
+            , userIsUltraRestricted = Just False
+            , userIsBot = Just True
+            , userUpdated = 1502138687s
+            }
+        , User
+            { userId = UserId
+                { unUserId = "W012A3CDE" }
+            , userName = "bob"
+            , userDeleted = True
+            , userColor = Just
+                ( Color
+                    { unColor = "4bbe2e" }
+                )
+            , userProfile = Nothing
+            , userIsAdmin = Just False
+            , userIsOwner = Just False
+            , userIsPrimaryOwner = Just False
+            , userIsRestricted = Just False
+            , userIsUltraRestricted = Just False
+            , userIsBot = Just False
+            , userUpdated = 1502138688s
+            }
+        ]
+    , listRspResponseMetadata = Just
+        ( ResponseMetadata
+            { responseMetadataNextCursor = Just
+                ( Cursor
+                    { unCursor = "" }
+                )
+            }
+        )
+    }

--- a/tests/golden/ListRsp/with_bots.json
+++ b/tests/golden/ListRsp/with_bots.json
@@ -1,0 +1,64 @@
+{
+    "ok": true,
+    "members": [
+        {
+            "id": "U023BECGF",
+            "name": "alice",
+            "deleted": false,
+            "color": "9f69e7",
+            "profile": {
+                "avatar_hash": "ge3b51ca72de",
+                "status_text": "Working remotely",
+                "status_emoji": ":house_with_garden:",
+                "real_name": "Alice Johnson",
+                "display_name": "alice",
+                "real_name_normalized": "Alice Johnson",
+                "display_name_normalized": "alice",
+                "email": "alice@example.com",
+                "image_24": "https://example.com/24.png",
+                "image_32": "https://example.com/32.png",
+                "image_48": "https://example.com/48.png",
+                "image_72": "https://example.com/72.png",
+                "image_192": "https://example.com/192.png",
+                "image_512": "https://example.com/512.png",
+                "team": "T012AB3C4"
+            },
+            "is_admin": true,
+            "is_owner": false,
+            "is_primary_owner": false,
+            "is_restricted": false,
+            "is_ultra_restricted": false,
+            "is_bot": false,
+            "updated": 1502138686
+        },
+        {
+            "id": "U061F7AUR",
+            "name": "good-morning-bot",
+            "deleted": false,
+            "color": "e7392d",
+            "is_admin": false,
+            "is_owner": false,
+            "is_primary_owner": false,
+            "is_restricted": false,
+            "is_ultra_restricted": false,
+            "is_bot": true,
+            "updated": 1502138687
+        },
+        {
+            "id": "W012A3CDE",
+            "name": "bob",
+            "deleted": true,
+            "color": "4bbe2e",
+            "is_admin": false,
+            "is_owner": false,
+            "is_primary_owner": false,
+            "is_restricted": false,
+            "is_ultra_restricted": false,
+            "is_bot": false,
+            "updated": 1502138688
+        }
+    ],
+    "response_metadata": {
+        "next_cursor": ""
+    }
+}


### PR DESCRIPTION
## Summary
- Adds golden test coverage for `users.list` response deserialization (`ListRsp`)
- The fixture includes three users exercising key fields:
  - A human user (`is_bot: false`) with full profile
  - A bot user (`is_bot: true`) without a profile
  - A deleted human user (`is_bot: false`, `deleted: true`)
- Exercises the `userIsBot` field added in #158

## Test plan
- [x] All 83 tests pass (82 existing + 1 new golden test)
- [x] Golden file correctly captures `userIsBot = Just True` for the bot and `Just False` for humans

Made with [Cursor](https://cursor.com)